### PR TITLE
Enhance Bling Token Refresh workflow with improved HTTP handling

### DIFF
--- a/.github/workflows/bling-token-refresh.yml
+++ b/.github/workflows/bling-token-refresh.yml
@@ -23,7 +23,8 @@ jobs:
             exit 1
           fi
 
-          HTTP_CODE=$(curl -sS -o response.json -w "%{http_code}" \
+          # -L segue 301/302/307/308 (ex.: http→https, www). Sem isso o 307 vira falha com corpo "Redirecting..."
+          HTTP_CODE=$(curl -sS -L --max-redirs 5 -o response.json -w "%{http_code}" \
             -X POST "$CRON_URL" \
             -H "Authorization: Bearer $CRON_SECRET" \
             -H "Content-Type: application/json")


### PR DESCRIPTION
- Updated the Bling token refresh workflow to include the `-L` option in the curl command, allowing for automatic handling of HTTP redirects (301/302/307/308).
- This change ensures that the workflow can successfully follow redirects, improving the reliability of the token refresh process.