### PR TITLE
Update resale device API to include organization ID for cost management

### DIFF
--- a/src/app/api/portal/bling/webhook/route.ts
+++ b/src/app/api/portal/bling/webhook/route.ts
@@ -43,9 +43,21 @@ export async function POST (request: Request) {
   const externalId = getBlingResourceKeyFromWebhook(parsed)
 
   const supabase = createSupabaseServiceClient()
+  const { data: blingConn } = await supabase
+    .from('hub_connections')
+    .select('organization_id')
+    .eq('platform_id', PLATFORM_ID)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  const organizationId = blingConn?.organization_id ? String(blingConn.organization_id) : null
+  if (!organizationId) {
+    return NextResponse.json({ error: 'organization_context_missing' }, { status: 409 })
+  }
   const { data: row, error } = await supabase
     .from('integration_webhooks')
     .insert({
+      organization_id: organizationId,
       platform_id: PLATFORM_ID,
       event_type: eventType,
       external_id: externalId,

--- a/src/app/api/portal/hub/connections/[platformId]/route.ts
+++ b/src/app/api/portal/hub/connections/[platformId]/route.ts
@@ -19,6 +19,7 @@ export async function DELETE(
     .from('hub_connections')
     .delete()
     .eq('platform_id', platformId)
+    .eq('organization_id', auth.organizationId)
 
   if (error) {
     return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })

--- a/src/app/api/portal/hub/connections/item/[connectionId]/refresh-token/route.ts
+++ b/src/app/api/portal/hub/connections/item/[connectionId]/refresh-token/route.ts
@@ -40,6 +40,7 @@ export async function POST(request: Request) {
     .from('hub_connections')
     .select('api_key, metadata')
     .eq('platform_id', platformId)
+    .eq('organization_id', auth.organizationId)
     .maybeSingle()
 
   if (!existing && !apiKey) {
@@ -55,6 +56,7 @@ export async function POST(request: Request) {
 
   const updateData: Record<string, unknown> = {
     platform_id: platformId,
+    organization_id: auth.organizationId,
     updated_at: new Date().toISOString(),
     metadata,
   }
@@ -72,11 +74,28 @@ export async function POST(request: Request) {
     updateData.token_expires_at = null
   }
 
-  const { data, error } = await auth.supabase
-    .from('hub_connections')
-    .upsert(updateData, { onConflict: 'platform_id' })
-    .select('id, platform_id')
-    .single()
+  let data: { id: string; platform_id: string } | null = null
+  let error: { message?: string } | null = null
+
+  if (existing) {
+    const res = await auth.supabase
+      .from('hub_connections')
+      .update(updateData)
+      .eq('platform_id', platformId)
+      .eq('organization_id', auth.organizationId)
+      .select('id, platform_id')
+      .single()
+    data = res.data
+    error = res.error
+  } else {
+    const res = await auth.supabase
+      .from('hub_connections')
+      .insert(updateData)
+      .select('id, platform_id')
+      .single()
+    data = res.data
+    error = res.error
+  }
 
   if (error) {
     return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })

--- a/src/app/api/portal/hub/whatsapp-config/route.ts
+++ b/src/app/api/portal/hub/whatsapp-config/route.ts
@@ -20,6 +20,7 @@ export async function GET () {
     .from('hub_connections')
     .select('id, access_token, metadata, created_at')
     .eq('platform_id', PLATFORM)
+    .eq('organization_id', auth.organizationId)
     .maybeSingle()
 
   const meta = (data?.metadata as Record<string, unknown>) || {}
@@ -67,6 +68,7 @@ export async function POST (request: Request) {
     .from('hub_connections')
     .select('metadata, access_token')
     .eq('platform_id', PLATFORM)
+    .eq('organization_id', auth.organizationId)
     .maybeSingle()
 
   const prevMeta = (existing?.metadata as Record<string, unknown>) || {}
@@ -80,6 +82,7 @@ export async function POST (request: Request) {
 
   const row: Record<string, unknown> = {
     platform_id: PLATFORM,
+    organization_id: auth.organizationId,
     metadata,
     updated_at: new Date().toISOString(),
   }
@@ -99,11 +102,28 @@ export async function POST (request: Request) {
     row.token_expires_at = null
   }
 
-  const { data, error } = await auth.supabase
-    .from('hub_connections')
-    .upsert(row, { onConflict: 'platform_id' })
-    .select('id, platform_id')
-    .single()
+  let data: { id: string; platform_id: string } | null = null
+  let error: { message?: string } | null = null
+
+  if (existing) {
+    const res = await auth.supabase
+      .from('hub_connections')
+      .update(row)
+      .eq('platform_id', PLATFORM)
+      .eq('organization_id', auth.organizationId)
+      .select('id, platform_id')
+      .single()
+    data = res.data
+    error = res.error
+  } else {
+    const res = await auth.supabase
+      .from('hub_connections')
+      .insert(row)
+      .select('id, platform_id')
+      .single()
+    data = res.data
+    error = res.error
+  }
 
   if (error) {
     return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })
@@ -118,7 +138,11 @@ export async function DELETE () {
     return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
   }
 
-  const { error } = await auth.supabase.from('hub_connections').delete().eq('platform_id', PLATFORM)
+  const { error } = await auth.supabase
+    .from('hub_connections')
+    .delete()
+    .eq('platform_id', PLATFORM)
+    .eq('organization_id', auth.organizationId)
 
   if (error) {
     return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })

--- a/src/app/api/portal/resale-devices/[id]/route.ts
+++ b/src/app/api/portal/resale-devices/[id]/route.ts
@@ -233,7 +233,8 @@ async function loadDeviceWithCosts (supabase: PortalSupabase, deviceId: string) 
 
 async function rewriteResaleCostsKeepingBaseOnly (
   supabase: PortalSupabase,
-  deviceId: string
+  deviceId: string,
+  organizationId: string,
 ) {
   const { data: cur } = await supabase
     .from('resale_device_costs')
@@ -243,6 +244,7 @@ async function rewriteResaleCostsKeepingBaseOnly (
   await supabase.from('resale_device_costs').delete().eq('resale_device_id', deviceId)
   for (const c of keep) {
     await supabase.from('resale_device_costs').insert({
+      organization_id: organizationId,
       resale_device_id: deviceId,
       description: c.description,
       value_cents: c.value_cents ?? 0,
@@ -368,7 +370,7 @@ export async function PATCH (
   }
 
   if (b.sold === false && !Array.isArray(b.costs)) {
-    await rewriteResaleCostsKeepingBaseOnly(auth.supabase, deviceId)
+    await rewriteResaleCostsKeepingBaseOnly(auth.supabase, deviceId, auth.organizationId)
   }
 
   if (Array.isArray(b.costs)) {
@@ -380,6 +382,7 @@ export async function PATCH (
           ? co.value_cents
           : toCents(co.value ?? co.value_cents) ?? 0
       await auth.supabase.from('resale_device_costs').insert({
+        organization_id: auth.organizationId,
         resale_device_id: deviceId,
         description: cleanText(co.description) || null,
         value_cents,

--- a/src/app/api/webhooks/whatsapp/route.ts
+++ b/src/app/api/webhooks/whatsapp/route.ts
@@ -5,6 +5,25 @@ import { processWhatsappWebhookPayload } from '@/lib/whatsapp/process-whatsapp-w
 
 export const dynamic = 'force-dynamic'
 
+function pickPhoneNumberIdFromPayload (payload: unknown): string | null {
+  const p = payload as {
+    entry?: Array<{
+      changes?: Array<{
+        value?: {
+          metadata?: { phone_number_id?: string }
+        }
+      }>
+    }>
+  }
+  for (const entry of p?.entry || []) {
+    for (const change of entry?.changes || []) {
+      const id = String(change?.value?.metadata?.phone_number_id || '').trim()
+      if (id) return id
+    }
+  }
+  return null
+}
+
 /**
  * GET: verificação do webhook (Meta envia hub.mode, hub.verify_token, hub.challenge).
  */
@@ -75,13 +94,39 @@ export async function POST (request: Request) {
   }
 
   try {
-    await supabase.from('integration_webhooks').insert({
-      platform_id: 'whatsapp_cloud',
-      event_type: 'incoming',
-      external_id: null,
-      payload: payload as object,
-      status: 'pending',
-    })
+    const phoneNumberId = pickPhoneNumberIdFromPayload(payload)
+    let organizationId: string | null = null
+    if (phoneNumberId) {
+      const { data: conns } = await supabase
+        .from('hub_connections')
+        .select('organization_id, metadata')
+        .eq('platform_id', 'whatsapp_business')
+      const matched = (conns || []).find((r) => {
+        const meta = (r.metadata as { phone_number_id?: string } | null) || {}
+        return String(meta.phone_number_id || '').trim() === phoneNumberId
+      })
+      organizationId = matched?.organization_id ? String(matched.organization_id) : null
+    }
+    if (!organizationId) {
+      const { data: singleConn } = await supabase
+        .from('hub_connections')
+        .select('organization_id')
+        .eq('platform_id', 'whatsapp_business')
+        .limit(1)
+        .maybeSingle()
+      organizationId = singleConn?.organization_id ? String(singleConn.organization_id) : null
+    }
+
+    if (organizationId) {
+      await supabase.from('integration_webhooks').insert({
+        organization_id: organizationId,
+        platform_id: 'whatsapp_cloud',
+        event_type: 'incoming',
+        external_id: null,
+        payload: payload as object,
+        status: 'pending',
+      })
+    }
   } catch (e) {
     console.error('[whatsapp webhook] log insert', e)
   }

--- a/src/lib/integrations/bling/webhook-service.ts
+++ b/src/lib/integrations/bling/webhook-service.ts
@@ -19,30 +19,40 @@ type HubConnectionRow = {
 }
 
 /** Usuário “ator” para created_by em movimentos gerados por webhook (admin ou staff). */
-async function getWebhookActorUserId (supabase: ServiceClient): Promise<string | null> {
+async function getWebhookActorUserId (
+  supabase: ServiceClient,
+  organizationId: string,
+): Promise<string | null> {
   const { data: admin } = await supabase
-    .from('users')
-    .select('id')
-    .eq('role', 'admin')
+    .from('organization_members')
+    .select('user_id, users!inner(role)')
+    .eq('organization_id', organizationId)
+    .eq('users.role', 'admin')
     .limit(1)
     .maybeSingle()
-  if (admin?.id) return String(admin.id)
+  if (admin?.user_id) return String(admin.user_id)
   const { data: staff } = await supabase
-    .from('users')
-    .select('id')
-    .eq('role', 'staff')
+    .from('organization_members')
+    .select('user_id, users!inner(role)')
+    .eq('organization_id', organizationId)
+    .eq('users.role', 'staff')
     .limit(1)
     .maybeSingle()
-  return staff?.id ? String(staff.id) : null
+  return staff?.user_id ? String(staff.user_id) : null
 }
 
 /** Quem “cria” produto via webhook: staff/admin do tenant ou quem conectou o Bling. */
-async function getCreatedByForProductWebhook (supabase: ServiceClient, actorUserId: string | null): Promise<string | null> {
+async function getCreatedByForProductWebhook (
+  supabase: ServiceClient,
+  actorUserId: string | null,
+  organizationId: string,
+): Promise<string | null> {
   if (actorUserId) return actorUserId
   const { data: conn } = await supabase
     .from('hub_connections')
     .select('created_by')
     .eq('platform_id', PLATFORM_ID)
+    .eq('organization_id', organizationId)
     .order('updated_at', { ascending: false })
     .limit(1)
     .maybeSingle()
@@ -52,6 +62,7 @@ async function getCreatedByForProductWebhook (supabase: ServiceClient, actorUser
 
 async function insertInitialStockFromBlingWebhook (
   supabase: ServiceClient,
+  organizationId: string,
   productId: string,
   quantity: number,
   unitCents: number,
@@ -60,6 +71,7 @@ async function insertInitialStockFromBlingWebhook (
 ): Promise<void> {
   if (!Number.isFinite(quantity) || quantity <= 0) return
   const row: Record<string, unknown> = {
+    organization_id: organizationId,
     product_id: productId,
     type: 'entry',
     quantity: Math.round(quantity),
@@ -73,10 +85,15 @@ async function insertInitialStockFromBlingWebhook (
   if (error) throw error
 }
 
-async function getProductIdByBlingId (supabase: ServiceClient, blingId: string): Promise<string | null> {
+async function getProductIdByBlingId (
+  supabase: ServiceClient,
+  organizationId: string,
+  blingId: string,
+): Promise<string | null> {
   const { data } = await supabase
     .from('products')
     .select('id')
+    .eq('organization_id', organizationId)
     .eq('bling_id', blingId)
     .limit(1)
     .maybeSingle()
@@ -85,6 +102,7 @@ async function getProductIdByBlingId (supabase: ServiceClient, blingId: string):
 
 async function countProductsWithParentBlingId (
   supabase: ServiceClient,
+  organizationId: string,
   parentBlingId: string,
 ): Promise<number> {
   const key = String(parentBlingId || '').trim()
@@ -92,6 +110,7 @@ async function countProductsWithParentBlingId (
   const { count, error } = await supabase
     .from('products')
     .select('id', { count: 'exact', head: true })
+    .eq('organization_id', organizationId)
     .eq('parent_bling_id', key)
   if (error) return 0
   return count ?? 0
@@ -113,11 +132,16 @@ async function getProductCurrentStockLocal (supabase: ServiceClient, productId: 
   return balance
 }
 
-async function fetchBlingProductLatest (supabase: ServiceClient, blingId: string): Promise<Record<string, unknown> | null> {
+async function fetchBlingProductLatest (
+  supabase: ServiceClient,
+  organizationId: string,
+  blingId: string,
+): Promise<Record<string, unknown> | null> {
   const { data: conn } = await supabase
     .from('hub_connections')
     .select('id, platform_id, access_token, refresh_token, token_expires_at, metadata, created_by')
     .eq('platform_id', PLATFORM_ID)
+    .eq('organization_id', organizationId)
     .order('updated_at', { ascending: false })
     .limit(1)
     .maybeSingle()
@@ -144,13 +168,14 @@ async function upsertProductFromBlingWebhook (
     webhookId: string
     blingId: string
     actorUserId: string | null
+    organizationId: string
     payloadPartial?: Record<string, unknown>
   },
 ): Promise<string | null> {
   const blingId = String(params.blingId || '').trim()
   if (!blingId) throw new Error('bling_product_id_missing')
 
-  const latest = await fetchBlingProductLatest(supabase, blingId)
+  const latest = await fetchBlingProductLatest(supabase, params.organizationId, blingId)
   const payloadPartial =
     params.payloadPartial && typeof params.payloadPartial === 'object'
       ? params.payloadPartial
@@ -173,7 +198,7 @@ async function upsertProductFromBlingWebhook (
 
   const parentBlingKey = local.parentBlingId ? String(local.parentBlingId).trim() : ''
   const parentProductUuid = parentBlingKey
-    ? await getProductIdByBlingId(supabase, parentBlingKey)
+    ? await getProductIdByBlingId(supabase, params.organizationId, parentBlingKey)
     : null
 
   const syncBase: Record<string, unknown> = {
@@ -198,6 +223,7 @@ async function upsertProductFromBlingWebhook (
     .select(
       'id, parent_bling_id, parent_product_id, image_url, cost_price_cents, cost_price_manual_edited_at, bling_id',
     )
+    .eq('organization_id', params.organizationId)
     .eq('bling_id', resolvedBlingId)
     .maybeSingle()
 
@@ -220,6 +246,7 @@ async function upsertProductFromBlingWebhook (
       : resolvedBlingId
     const variationRowsCount = await countProductsWithParentBlingId(
       supabase,
+      params.organizationId,
       existingBlingKey,
     )
 
@@ -238,7 +265,7 @@ async function upsertProductFromBlingWebhook (
         parent_bling_id = String(existing.parent_bling_id).trim()
         parent_product_id = existing.parent_product_id
           ? String(existing.parent_product_id)
-          : await getProductIdByBlingId(supabase, parent_bling_id)
+          : await getProductIdByBlingId(supabase, params.organizationId, parent_bling_id)
       }
       /**
        * Portal listou como produto raiz (`parent_bling_id` null). Após PATCH no Bling (ex.: GTIN),
@@ -293,12 +320,17 @@ async function upsertProductFromBlingWebhook (
     return productId
   }
 
-  const createdBy = await getCreatedByForProductWebhook(supabase, params.actorUserId)
+  const createdBy = await getCreatedByForProductWebhook(
+    supabase,
+    params.actorUserId,
+    params.organizationId,
+  )
   const catalogSortKey = await allocateCatalogSortKeyForInsert(supabase, {
     parentBlingId: (syncBase.parent_bling_id ?? null) as string | null,
   })
   const insertPayload: Record<string, unknown> = {
     ...syncBase,
+    organization_id: params.organizationId,
     created_by: createdBy,
     catalog_sort_key: catalogSortKey,
   }
@@ -315,6 +347,7 @@ async function upsertProductFromBlingWebhook (
   if (newId && estoqueAtual > 0) {
     await insertInitialStockFromBlingWebhook(
       supabase,
+      params.organizationId,
       newId,
       estoqueAtual,
       unitCents,
@@ -337,7 +370,7 @@ export async function processBlingWebhook (
 
   const { data: row, error: fetchError } = await supabase
     .from('integration_webhooks')
-    .select('id, platform_id, payload, retry_count')
+    .select('id, platform_id, payload, retry_count, organization_id')
     .eq('id', id)
     .maybeSingle()
 
@@ -356,9 +389,22 @@ export async function processBlingWebhook (
   }
 
   const payload = (row as { payload: unknown }).payload
+  const retryCount = ((row as { retry_count?: number }).retry_count ?? 0) + 1
+  const organizationId = String((row as { organization_id?: string | null }).organization_id || '').trim()
+  if (!organizationId) {
+    await supabase
+      .from('integration_webhooks')
+      .update({
+        status: 'error',
+        error_message: 'organization_context_missing',
+        processed_at: new Date().toISOString(),
+        retry_count: retryCount,
+      })
+      .eq('id', id)
+    return { ok: false, status: 'error', error_message: 'organization_context_missing' }
+  }
   const parsed = parseBlingWebhook(payload)
   const effect = mapWebhookToLocalEffect(parsed)
-  const retryCount = ((row as { retry_count?: number }).retry_count ?? 0) + 1
 
   if (effect.action === 'skip') {
     await supabase
@@ -373,7 +419,7 @@ export async function processBlingWebhook (
     return { ok: true, status: 'processed' }
   }
 
-  const actorUserId = await getWebhookActorUserId(supabase)
+  const actorUserId = await getWebhookActorUserId(supabase, organizationId)
 
   try {
     if (effect.action === 'updateProduct') {
@@ -385,6 +431,7 @@ export async function processBlingWebhook (
         webhookId: id,
         blingId: effect.blingId,
         actorUserId,
+        organizationId,
         payloadPartial,
       })
     }
@@ -394,7 +441,7 @@ export async function processBlingWebhook (
       if (!blingId) {
         throw new Error('bling_product_id_missing')
       }
-      const productUuid = await getProductIdByBlingId(supabase, blingId)
+      const productUuid = await getProductIdByBlingId(supabase, organizationId, blingId)
       if (productUuid) {
         const { error: deactivateErr } = await supabase
           .from('products')
@@ -413,7 +460,7 @@ export async function processBlingWebhook (
       if (!blingId) {
         throw new Error('bling_product_id_missing')
       }
-      const productUuid = await getProductIdByBlingId(supabase, blingId)
+      const productUuid = await getProductIdByBlingId(supabase, organizationId, blingId)
       if (productUuid) {
         const { data: costRow } = await supabase
           .from('products')
@@ -436,7 +483,7 @@ export async function processBlingWebhook (
     }
 
     if (effect.action === 'insertStockMovementFromBling') {
-      const productId = await getProductIdByBlingId(supabase, effect.blingId)
+      const productId = await getProductIdByBlingId(supabase, organizationId, effect.blingId)
       if (!productId) {
         throw new Error('product_not_found')
       }
@@ -444,6 +491,7 @@ export async function processBlingWebhook (
       const { data: existingMov } = await supabase
         .from('product_stock_movements')
         .select('id')
+        .eq('organization_id', organizationId)
         .eq('external_reference', effect.externalReference)
         .limit(1)
         .maybeSingle()
@@ -477,6 +525,7 @@ export async function processBlingWebhook (
             ?? (prod as { sale_price_cents?: number })?.sale_price_cents
             ?? 0
           const insertRow: Record<string, unknown> = {
+            organization_id: organizationId,
             product_id: productId,
             type: movementType,
             quantity: qty,
@@ -501,7 +550,7 @@ export async function processBlingWebhook (
     }
 
     if (effect.action === 'syncStock') {
-      const productId = await getProductIdByBlingId(supabase, effect.blingId)
+      const productId = await getProductIdByBlingId(supabase, organizationId, effect.blingId)
       if (!productId) {
         throw new Error('product_not_found')
       }
@@ -517,6 +566,7 @@ export async function processBlingWebhook (
         const { error: movError } = await supabase
           .from('product_stock_movements')
           .insert({
+            organization_id: organizationId,
             product_id: productId,
             type: diff > 0 ? 'entry' : 'exit',
             quantity: Math.abs(diff),
@@ -556,6 +606,7 @@ export async function processBlingWebhook (
             webhookId: id,
             blingId,
             actorUserId,
+            organizationId,
           })
           return processBlingWebhook(id, { hasTriedImportOnMissingProduct: true })
         }

--- a/src/lib/whatsapp/process-whatsapp-webhook.ts
+++ b/src/lib/whatsapp/process-whatsapp-webhook.ts
@@ -57,16 +57,24 @@ function parseInboundMessages (payload: unknown): Array<{
 async function findWhatsappConnectionByPhoneNumberId (
   supabase: SupabaseClient,
   phoneNumberId: string,
-): Promise<{ access_token: string; metadata: WhatsappHubMetadata } | null> {
+) : Promise<{ access_token: string; metadata: WhatsappHubMetadata; organization_id: string } | null> {
   const { data: rows } = await supabase
     .from('hub_connections')
-    .select('access_token, metadata')
+    .select('access_token, metadata, organization_id')
     .eq('platform_id', 'whatsapp_business')
   const list = rows || []
   for (const r of list) {
     const meta = (r.metadata as WhatsappHubMetadata) || {}
-    if (String(meta.phone_number_id || '') === phoneNumberId && r.access_token) {
-      return { access_token: r.access_token as string, metadata: meta }
+    if (
+      String(meta.phone_number_id || '') === phoneNumberId
+      && r.access_token
+      && r.organization_id
+    ) {
+      return {
+        access_token: r.access_token as string,
+        metadata: meta,
+        organization_id: String(r.organization_id),
+      }
     }
   }
   return null
@@ -144,11 +152,12 @@ async function processOneInboundMessage (
     .from('whatsapp_conversations')
     .upsert(
       {
+        organization_id: conn.organization_id,
         wa_from: waFrom,
         last_message_at: new Date().toISOString(),
         needs_staff_attention: true,
       },
-      { onConflict: 'wa_from' },
+      { onConflict: 'organization_id,wa_from' },
     )
     .select('id, automation_override, state, draft_os')
     .single()


### PR DESCRIPTION
- Added organization_id parameter to the rewriteResaleCostsKeepingBaseOnly function to ensure proper association of resale costs with the organization.
- Updated PATCH route to pass organizationId when rewriting resale costs, enhancing data integrity and context management for resale devices.