### PR TITLE
Update WhatsApp broadcast schedule and refine routine status messaging

### DIFF
--- a/.github/workflows/whatsapp-seminovos-lojistas-broadcast.yml
+++ b/.github/workflows/whatsapp-seminovos-lojistas-broadcast.yml
@@ -2,8 +2,10 @@ name: WhatsApp Lista Lojistas Seminovos
 
 on:
   schedule:
-    # 10:00 America/Sao_Paulo (BRT, UTC-3) = 13:00 UTC
-    - cron: '0 13 * * *'
+    # Alvo: ~09:00 America/Sao_Paulo (BRT, UTC-3) = 12:00 UTC.
+    # Agendado 11:40 UTC (08:40 BRT) fora do minuto 0 porque o GitHub Actions
+    # costuma atrasar crons em horários concorridos (chegou a rodar 2h depois).
+    - cron: '40 11 * * *'
   workflow_dispatch:
 
 jobs:

--- a/src/app/(portal)/portal/hub/HubClient.tsx
+++ b/src/app/(portal)/portal/hub/HubClient.tsx
@@ -221,7 +221,7 @@ function lojistasRoutineBadge (routine: LojistasRoutineStatus): {
     }
     return { label: 'Falhou hoje', variant: 'destructive' }
   }
-  return { label: 'Agendada · 10h', variant: 'outline' }
+  return { label: 'Agendada · ~9h', variant: 'outline' }
 }
 
 function isBlingTokenExpired (expiresAt: string | null | undefined) {
@@ -320,7 +320,7 @@ function LojistasRoutinePanel ({
         </Badge>
       </div>
       <p className="text-xs text-muted-foreground">
-        Envia diariamente às 10h (via GitHub Actions) a lista de atacado no grupo do WhatsApp.
+        Envia diariamente por volta das 9h (via GitHub Actions) a lista de atacado no grupo do WhatsApp.
       </p>
       {last ? (
         <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
- Adjusted the cron schedule for the WhatsApp broadcast to run at 11:40 UTC to mitigate delays in GitHub Actions.
- Updated routine status labels in the HubClient component to reflect the new broadcast time, ensuring clarity in user notifications.
- Maintained strict TypeScript definitions and adhered to semantic HTML structure throughout the changes.