### PR TITLE
Remove unused 'service' field from create order actions and database …

### DIFF
--- a/src/app/(portal)/portal/ordens/nova/create-order-action.ts
+++ b/src/app/(portal)/portal/ordens/nova/create-order-action.ts
@@ -50,7 +50,6 @@ export async function createOrderAction(formData: FormData) {
   const brand = String(formData.get('brand') || '').trim()
   const model = String(formData.get('model') || '').trim()
   const deviceType = String(formData.get('deviceType') || '').trim()
-  const service = ''
 
   if (!document || (document.length !== 11 && document.length !== 14)) {
     redirect(`/portal/ordens/nova?error=${document && document.length > 11 ? 'cnpj_invalido' : 'cpf_invalido'}`)
@@ -115,7 +114,6 @@ export async function createOrderAction(formData: FormData) {
       status,
       brand: brand || null,
       model: model || null,
-      service: service || null,
       created_by: user.id,
       seller_user_id: sellerUserId,
       device_model_id: deviceModelId,

--- a/src/app/(portal)/portal/whatsapp/whatsapp-create-order-action.ts
+++ b/src/app/(portal)/portal/whatsapp/whatsapp-create-order-action.ts
@@ -110,7 +110,6 @@ export async function createOrderFromWhatsappConversationAction (
       status: 'orcamento',
       brand: null,
       model: null,
-      service: null,
       created_by: user.id,
       seller_user_id: user.id,
       device_model_id: null,

--- a/supabase/migrations/20260303100000_baseline_customers_service_orders_resale_devices.sql
+++ b/supabase/migrations/20260303100000_baseline_customers_service_orders_resale_devices.sql
@@ -102,7 +102,6 @@ create table if not exists public.service_orders (
   device text,
   brand text,
   model text,
-  service text,
   created_by uuid null references auth.users(id) on delete set null,
   seller_user_id uuid null references auth.users(id) on delete set null,
   device_model_id uuid null references public.device_models(id) on delete set null,

--- a/supabase/migrations/20260723230000_drop_service_orders_service.sql
+++ b/supabase/migrations/20260723230000_drop_service_orders_service.sql
@@ -1,0 +1,4 @@
+-- Remove coluna legada `service` de service_orders (substituída por `services` jsonb + `title`).
+
+alter table public.service_orders
+  drop column if exists service;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -427,7 +427,6 @@ create table if not exists public.service_orders (
   device text,
   brand text,
   model text,
-  service text,
   created_by uuid null references auth.users(id) on delete set null,
   seller_user_id uuid null references auth.users(id) on delete set null,
   device_model_id uuid null references public.device_models(id) on delete set null,


### PR DESCRIPTION
…schema

- Eliminated the 'service' field from the createOrderAction and createOrderFromWhatsappConversationAction functions to streamline data handling.
- Updated the database schema and migration files to reflect the removal of the 'service' column from the service_orders table.
- Ensured compliance with strict TypeScript definitions and maintained semantic HTML structure throughout the changes.