### PR TITLE
Enhance order photo management by adding assistance photo support

### DIFF
--- a/src/app/(portal)/portal/admin/armazenamento/StorageUsageClient.tsx
+++ b/src/app/(portal)/portal/admin/armazenamento/StorageUsageClient.tsx
@@ -54,6 +54,7 @@ function formatPercent (value: number): string {
 function categoryDescription (key: string): string {
   if (key === 'os_entry') return 'Bucket order-entry-photos'
   if (key === 'os_exit') return 'Bucket order-exit-photos'
+  if (key === 'os_assistance') return 'Bucket order-assistance-photos'
   if (key === 'whatsapp') return 'Bucket whatsapp-media'
   if (key === 'resale') return 'Bucket resale-device-photos'
   return 'Mídias armazenadas'

--- a/src/app/(portal)/portal/admin/presets/ServiceOrderPhotosBrowserDialog.tsx
+++ b/src/app/(portal)/portal/admin/presets/ServiceOrderPhotosBrowserDialog.tsx
@@ -56,7 +56,9 @@ function formatPhotoDate (iso: string): string {
 }
 
 function kindLabel (kind: ServiceOrderPhotoKind): string {
-  return kind === 'entry' ? 'Entrada' : 'Saída'
+  if (kind === 'entry') return 'Entrada'
+  if (kind === 'exit') return 'Saída'
+  return 'Assistência'
 }
 
 export function ServiceOrderPhotosBrowserDialog ({

--- a/src/app/(portal)/portal/admin/presets/ServiceOrderPhotosCleanupCard.tsx
+++ b/src/app/(portal)/portal/admin/presets/ServiceOrderPhotosCleanupCard.tsx
@@ -23,6 +23,7 @@ type PreviewResponse = {
   ok?: boolean
   entryCount?: number
   exitCount?: number
+  assistanceCount?: number
   totalCount?: number
   cutoffAt?: string
   retentionMonths?: number
@@ -32,6 +33,7 @@ type PreviewResponse = {
 type CleanupResponse = PreviewResponse & {
   entryDeleted?: number
   exitDeleted?: number
+  assistanceDeleted?: number
   storageRemoveErrors?: number
 }
 
@@ -51,6 +53,7 @@ export function ServiceOrderPhotosCleanupCard ({
 }: ServiceOrderPhotosCleanupCardProps) {
   const [entryCount, setEntryCount] = useState<number | null>(null)
   const [exitCount, setExitCount] = useState<number | null>(null)
+  const [assistanceCount, setAssistanceCount] = useState<number | null>(null)
   const [cutoffAt, setCutoffAt] = useState<string | null>(null)
   const [retentionMonths, setRetentionMonths] = useState(3)
   const [isLoadingPreview, setIsLoadingPreview] = useState(true)
@@ -67,6 +70,7 @@ export function ServiceOrderPhotosCleanupCard ({
       }
       setEntryCount(data.entryCount ?? 0)
       setExitCount(data.exitCount ?? 0)
+      setAssistanceCount(data.assistanceCount ?? 0)
       setCutoffAt(data.cutoffAt ?? null)
       setRetentionMonths(data.retentionMonths ?? 3)
     } catch (err) {
@@ -74,6 +78,7 @@ export function ServiceOrderPhotosCleanupCard ({
       toast({ variant: 'destructive', title: 'Erro', description: message })
       setEntryCount(null)
       setExitCount(null)
+      setAssistanceCount(null)
     } finally {
       setIsLoadingPreview(false)
     }
@@ -83,7 +88,7 @@ export function ServiceOrderPhotosCleanupCard ({
     void loadPreview()
   }, [loadPreview])
 
-  const totalCount = (entryCount ?? 0) + (exitCount ?? 0)
+  const totalCount = (entryCount ?? 0) + (exitCount ?? 0) + (assistanceCount ?? 0)
 
   async function handleCleanup () {
     if (isCleaning) return
@@ -97,7 +102,8 @@ export function ServiceOrderPhotosCleanupCard ({
         throw new Error(data?.error || 'Não foi possível excluir as fotos.')
       }
 
-      const deleted = (data.entryDeleted ?? 0) + (data.exitDeleted ?? 0)
+      const deleted =
+        (data.entryDeleted ?? 0) + (data.exitDeleted ?? 0) + (data.assistanceDeleted ?? 0)
       const storageErrors = data.storageRemoveErrors ?? 0
 
       toast({
@@ -106,7 +112,7 @@ export function ServiceOrderPhotosCleanupCard ({
         description:
           storageErrors > 0
             ? `${deleted} referência(s) removida(s); ${storageErrors} arquivo(s) no storage falharam.`
-            : `${deleted} foto(s) de OS removida(s) (entrada: ${data.entryDeleted ?? 0}, saída: ${data.exitDeleted ?? 0}).`,
+            : `${deleted} foto(s) de OS removida(s) (entrada: ${data.entryDeleted ?? 0}, saída: ${data.exitDeleted ?? 0}, assistência: ${data.assistanceDeleted ?? 0}).`,
       })
 
       setDialogOpen(false)
@@ -125,7 +131,7 @@ export function ServiceOrderPhotosCleanupCard ({
       <CardHeader>
         <CardTitle>Fotos de ordens de serviço</CardTitle>
         <CardDescription>
-          Remove fotos de entrada e saída com mais de {retentionMonths} meses, apagando o arquivo no
+          Remove fotos de entrada, saída e assistência com mais de {retentionMonths} meses, apagando o arquivo no
           storage e a referência no banco de dados.
         </CardDescription>
       </CardHeader>
@@ -146,7 +152,7 @@ export function ServiceOrderPhotosCleanupCard ({
             <>
               <p>
                 <span className="font-medium text-foreground">{totalCount}</span> foto(s) elegíveis
-                (entrada: {entryCount}, saída: {exitCount}).
+                (entrada: {entryCount}, saída: {exitCount}, assistência: {assistanceCount}).
               </p>
               <p>Criadas antes de {formatCutoffDate(cutoffAt ?? undefined)}.</p>
             </>

--- a/src/app/(portal)/portal/aparelhos/AparelhosClient.tsx
+++ b/src/app/(portal)/portal/aparelhos/AparelhosClient.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { portalFetch } from "@/lib/portal/portal-fetch";
+import { canManageDeviceCatalogItem } from "@/lib/organizations/device-catalog";
 import {
 	ChevronDown,
 	ChevronRight,
@@ -53,11 +54,17 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-type DeviceBrandRow = { id: string; name: string; created_at?: string | null };
+type DeviceBrandRow = {
+	id: string;
+	name: string;
+	organization_id?: string | null;
+	created_at?: string | null;
+};
 type DeviceTypeRow = {
 	id: string;
 	brand_id: string;
 	name: string;
+	organization_id?: string | null;
 	brand_name?: string | null;
 	created_at?: string | null;
 };
@@ -65,6 +72,7 @@ export type DeviceModelRow = {
 	id: string;
 	model: string;
 	device_type_id?: string | null;
+	organization_id?: string | null;
 	brand?: string | null;
 	device_type?: string | null;
 	created_at?: string | null;
@@ -74,14 +82,24 @@ function cleanText(value: string) {
 	return String(value || "").trim();
 }
 
+function SharedCatalogBadge() {
+	return (
+		<span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+			Conectize
+		</span>
+	);
+}
+
 function BrandCollapsible({
 	brand,
+	canManage,
 	deviceTypes,
 	isLoadingDevices,
 	onOpen,
 	getModelsForDeviceType,
 	onLoadModels,
 	loadingModelIds,
+	currentOrganizationId,
 	onAddDevice,
 	onAddAparelho,
 	onEditMarca,
@@ -92,6 +110,7 @@ function BrandCollapsible({
 	onDeleteModel,
 }: {
 	brand: DeviceBrandRow;
+	canManage: boolean;
 	deviceTypes: DeviceTypeRow[] | undefined;
 	isLoadingDevices: boolean;
 	onOpen: (brandId: string) => void;
@@ -100,6 +119,7 @@ function BrandCollapsible({
 	) => DeviceModelRow[] | undefined;
 	onLoadModels: (deviceTypeId: string) => void;
 	loadingModelIds: Set<string>;
+	currentOrganizationId: string | null;
 	onAddDevice: (brand: DeviceBrandRow) => void;
 	onAddAparelho: (deviceType: DeviceTypeRow) => void;
 	onEditMarca: () => void;
@@ -124,6 +144,7 @@ function BrandCollapsible({
 						<ChevronRight className="h-4 w-4 shrink-0" />
 					)}
 					<span className="truncate">{brand.name}</span>
+					{!canManage ? <SharedCatalogBadge /> : null}
 				</CollapsibleTrigger>
 				<Button
 					variant="ghost"
@@ -137,30 +158,32 @@ function BrandCollapsible({
 				>
 					<Plus className="h-4 w-4" />
 				</Button>
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon"
-							className="h-8 w-8 shrink-0"
-							aria-label="Ações marca"
-							onClick={(e) => e.stopPropagation()}
-						>
-							<MoreHorizontal className="h-4 w-4" />
-						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end">
-						<DropdownMenuItem onClick={onEditMarca}>
-							<Pencil className="mr-2 h-4 w-4" /> Editar marca
-						</DropdownMenuItem>
-						<DropdownMenuItem
-							className="text-destructive focus:text-destructive"
-							onClick={onDeleteMarca}
-						>
-							<Trash2 className="mr-2 h-4 w-4" /> Excluir marca
-						</DropdownMenuItem>
-					</DropdownMenuContent>
-				</DropdownMenu>
+				{canManage ? (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon"
+								className="h-8 w-8 shrink-0"
+								aria-label="Ações marca"
+								onClick={(e) => e.stopPropagation()}
+							>
+								<MoreHorizontal className="h-4 w-4" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem onClick={onEditMarca}>
+								<Pencil className="mr-2 h-4 w-4" /> Editar marca
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="text-destructive focus:text-destructive"
+								onClick={onDeleteMarca}
+							>
+								<Trash2 className="mr-2 h-4 w-4" /> Excluir marca
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				) : null}
 			</div>
 			<CollapsibleContent>
 				<div className="pl-4 pt-1 pb-1 space-y-1 border-l-2 border-border/40 ml-2">
@@ -179,9 +202,14 @@ function BrandCollapsible({
 								key={dt.id}
 								brandName={brand.name}
 								deviceType={dt}
+								canManage={canManageDeviceCatalogItem(
+									dt.organization_id,
+									currentOrganizationId,
+								)}
 								models={getModelsForDeviceType(dt.id)}
 								isLoadingModels={loadingModelIds.has(dt.id)}
 								onOpen={onLoadModels}
+								currentOrganizationId={currentOrganizationId}
 								onAddAparelho={onAddAparelho}
 								onEditDisp={() => onEditDisp(dt)}
 								onDeleteDisp={() => onDeleteDisp(dt)}
@@ -199,9 +227,11 @@ function BrandCollapsible({
 function DeviceTypeCollapsible({
 	brandName: _brandName,
 	deviceType,
+	canManage,
 	models,
 	isLoadingModels,
 	onOpen,
+	currentOrganizationId,
 	onAddAparelho,
 	onEditDisp,
 	onDeleteDisp,
@@ -210,9 +240,11 @@ function DeviceTypeCollapsible({
 }: {
 	brandName: string;
 	deviceType: DeviceTypeRow;
+	canManage: boolean;
 	models: DeviceModelRow[] | undefined;
 	isLoadingModels: boolean;
 	onOpen: (deviceTypeId: string) => void;
+	currentOrganizationId: string | null;
 	onAddAparelho: (deviceType: DeviceTypeRow) => void;
 	onEditDisp: () => void;
 	onDeleteDisp: () => void;
@@ -234,6 +266,7 @@ function DeviceTypeCollapsible({
 						<ChevronRight className="h-4 w-4 shrink-0" />
 					)}
 					<span className="truncate">{deviceType.name}</span>
+					{!canManage ? <SharedCatalogBadge /> : null}
 				</CollapsibleTrigger>
 				<Button
 					variant="ghost"
@@ -247,32 +280,34 @@ function DeviceTypeCollapsible({
 				>
 					<Plus className="h-3.5 w-3.5" />
 				</Button>
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon"
-							className="h-7 w-7 shrink-0"
-							aria-label="Ações dispositivo"
-							onClick={(e) => e.stopPropagation()}
-						>
-							<MoreHorizontal className="h-3.5 w-3.5" />
-						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end">
-						<DropdownMenuItem onClick={onEditDisp}>
-							<Pencil className="mr-2 h-4 w-4" /> Editar
-							dispositivo
-						</DropdownMenuItem>
-						<DropdownMenuItem
-							className="text-destructive focus:text-destructive"
-							onClick={onDeleteDisp}
-						>
-							<Trash2 className="mr-2 h-4 w-4" /> Excluir
-							dispositivo
-						</DropdownMenuItem>
-					</DropdownMenuContent>
-				</DropdownMenu>
+				{canManage ? (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon"
+								className="h-7 w-7 shrink-0"
+								aria-label="Ações dispositivo"
+								onClick={(e) => e.stopPropagation()}
+							>
+								<MoreHorizontal className="h-3.5 w-3.5" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem onClick={onEditDisp}>
+								<Pencil className="mr-2 h-4 w-4" /> Editar
+								dispositivo
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="text-destructive focus:text-destructive"
+								onClick={onDeleteDisp}
+							>
+								<Trash2 className="mr-2 h-4 w-4" /> Excluir
+								dispositivo
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				) : null}
 			</div>
 			<CollapsibleContent>
 				<div className="pl-4 pt-1 space-y-0 border-l-2 border-border/40 ml-2">
@@ -288,49 +323,69 @@ function DeviceTypeCollapsible({
 					) : (
 						<Table>
 							<TableBody>
-								{models.map((r) => (
-									<TableRow
-										key={r.id}
-										className="hover:bg-muted/20"
-									>
-										<TableCell className="font-medium py-1 h-auto text-sm">
-											{r.model}
-										</TableCell>
-										<TableCell className="text-right py-1 h-auto">
-											<DropdownMenu>
-												<DropdownMenuTrigger asChild>
-													<Button
-														variant="ghost"
-														size="icon"
-														className="h-7 w-7"
-														aria-label="Ações"
-													>
-														<MoreHorizontal className="h-4 w-4" />
-													</Button>
-												</DropdownMenuTrigger>
-												<DropdownMenuContent align="end">
-													<DropdownMenuItem
-														onClick={() =>
-															onEditModel(r)
-														}
-													>
-														<Pencil className="mr-2 h-4 w-4" />{" "}
-														Editar
-													</DropdownMenuItem>
-													<DropdownMenuItem
-														className="text-destructive focus:text-destructive"
-														onClick={() =>
-															onDeleteModel(r)
-														}
-													>
-														<Trash2 className="mr-2 h-4 w-4" />{" "}
-														Excluir
-													</DropdownMenuItem>
-												</DropdownMenuContent>
-											</DropdownMenu>
-										</TableCell>
-									</TableRow>
-								))}
+								{models.map((r) => {
+									const canManageModel =
+										canManageDeviceCatalogItem(
+											r.organization_id,
+											currentOrganizationId,
+										);
+									return (
+										<TableRow
+											key={r.id}
+											className="hover:bg-muted/20"
+										>
+											<TableCell className="font-medium py-1 h-auto text-sm">
+												<span className="inline-flex items-center gap-2">
+													{r.model}
+													{!canManageModel ? (
+														<SharedCatalogBadge />
+													) : null}
+												</span>
+											</TableCell>
+											<TableCell className="text-right py-1 h-auto">
+												{canManageModel ? (
+													<DropdownMenu>
+														<DropdownMenuTrigger
+															asChild
+														>
+															<Button
+																variant="ghost"
+																size="icon"
+																className="h-7 w-7"
+																aria-label="Ações"
+															>
+																<MoreHorizontal className="h-4 w-4" />
+															</Button>
+														</DropdownMenuTrigger>
+														<DropdownMenuContent align="end">
+															<DropdownMenuItem
+																onClick={() =>
+																	onEditModel(
+																		r,
+																	)
+																}
+															>
+																<Pencil className="mr-2 h-4 w-4" />{" "}
+																Editar
+															</DropdownMenuItem>
+															<DropdownMenuItem
+																className="text-destructive focus:text-destructive"
+																onClick={() =>
+																	onDeleteModel(
+																		r,
+																	)
+																}
+															>
+																<Trash2 className="mr-2 h-4 w-4" />{" "}
+																Excluir
+															</DropdownMenuItem>
+														</DropdownMenuContent>
+													</DropdownMenu>
+												) : null}
+											</TableCell>
+										</TableRow>
+									);
+								})}
 							</TableBody>
 						</Table>
 					)}
@@ -352,6 +407,9 @@ export function AparelhosClient({
 	initialModelQuery?: string;
 }) {
 	const [deviceBrands, setDeviceBrands] = useState<DeviceBrandRow[]>([]);
+	const [currentOrganizationId, setCurrentOrganizationId] = useState<
+		string | null
+	>(null);
 	const [deviceTypesByBrand, setDeviceTypesByBrand] = useState<
 		Record<string, DeviceTypeRow[]>
 	>({});
@@ -370,6 +428,9 @@ export function AparelhosClient({
 		const json = await res?.json().catch(() => null);
 		if (json?.ok && Array.isArray(json.deviceBrands)) {
 			setDeviceBrands(json.deviceBrands);
+			if (typeof json.currentOrganizationId === "string") {
+				setCurrentOrganizationId(json.currentOrganizationId);
+			}
 		}
 	}, []);
 
@@ -938,6 +999,11 @@ export function AparelhosClient({
 				<h2 className="text-sm font-medium text-muted-foreground mb-2">
 					Marcas
 				</h2>
+				<p className="text-xs text-muted-foreground mb-2 px-2">
+					Itens com selo Conectize vêm do catálogo compartilhado e
+					podem ser usados por todas as empresas. Novos cadastros
+					ficam só na sua companhia.
+				</p>
 				<div className="space-y-1">
 					{deviceBrands.length === 0 ? (
 						<p className="text-sm text-muted-foreground py-3 px-2">
@@ -949,12 +1015,17 @@ export function AparelhosClient({
 							<BrandCollapsible
 								key={b.id}
 								brand={b}
+								canManage={canManageDeviceCatalogItem(
+									b.organization_id,
+									currentOrganizationId,
+								)}
 								deviceTypes={deviceTypesByBrand[b.id]}
 								isLoadingDevices={loadingBrandIdsSet.has(b.id)}
 								onOpen={onBrandOpen}
 								getModelsForDeviceType={getModelsForDeviceType}
 								onLoadModels={onDeviceTypeOpen}
 								loadingModelIds={loadingModelIdsSet}
+								currentOrganizationId={currentOrganizationId}
 								onAddDevice={(brand) => {
 									setDispBrandId(brand.id);
 									setDispName("");

--- a/src/app/(portal)/portal/financeiro/FinanceiroSubmenu.tsx
+++ b/src/app/(portal)/portal/financeiro/FinanceiroSubmenu.tsx
@@ -2,11 +2,12 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { List, Landmark, CreditCard } from 'lucide-react'
+import { List, Landmark, CreditCard, Percent } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 const submenuItems = [
   { href: '/portal/financeiro', label: 'Movimentação', icon: List, exact: true },
+  { href: '/portal/financeiro/comissoes', label: 'Comissões', icon: Percent, exact: false },
   { href: '/portal/financeiro/bancos', label: 'Carteiras', icon: Landmark, exact: false },
   { href: '/portal/financeiro/formas-pagamento', label: 'Formas de pagamento', icon: CreditCard, exact: false },
 ]

--- a/src/app/(portal)/portal/financeiro/comissoes/FinanceiroComissoesClient.tsx
+++ b/src/app/(portal)/portal/financeiro/comissoes/FinanceiroComissoesClient.tsx
@@ -1,0 +1,489 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { format } from 'date-fns'
+import { ptBR } from 'date-fns/locale'
+import { Loader2, Percent, RefreshCw } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { toast } from '@/hooks/use-toast'
+import type { StaffCommissionItem } from '@/lib/finance/staff-commissions'
+import { portalFetch } from '@/lib/portal/portal-fetch'
+import { maskedFromCents } from '@/lib/utils/money'
+
+type Totals = {
+  pendingCents: number
+  paidCents: number
+  totalCents: number
+  count: number
+}
+
+type ListResponse = {
+  ok?: boolean
+  from?: string
+  to?: string
+  items?: StaffCommissionItem[]
+  totals?: Totals
+  error?: string
+}
+
+const PRESETS = [
+  { from: 'thisMonth', to: 'Este mês' },
+  { from: 'lastMonth', to: 'Mês passado' },
+  { from: 'thisYear', to: 'Este ano' },
+  { from: 'custom', to: 'Período customizado' },
+] as const
+
+function buildRange (preset: string): { from: string; to: string } {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = now.getMonth()
+  const d = now.getDate()
+  const fmt = (date: Date) => date.toISOString().slice(0, 10)
+  if (preset === 'thisMonth') {
+    return { from: fmt(new Date(y, m, 1)), to: fmt(new Date(y, m, d)) }
+  }
+  if (preset === 'lastMonth') {
+    return { from: fmt(new Date(y, m - 1, 1)), to: fmt(new Date(y, m, 0)) }
+  }
+  if (preset === 'thisYear') {
+    return { from: fmt(new Date(y, 0, 1)), to: fmt(new Date(y, m, d)) }
+  }
+  return { from: fmt(new Date(y, m, 1)), to: fmt(new Date(y, m, d)) }
+}
+
+function formatDateBr (ymd: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(ymd)) return '—'
+  const [y, mo, d] = ymd.split('-')
+  return `${d}/${mo}/${y}`
+}
+
+function sourceLabel (source: StaffCommissionItem['source']): string {
+  return source === 'os' ? 'OS' : 'Aparelho'
+}
+
+export function FinanceiroComissoesClient () {
+  const initial = useMemo(() => buildRange('thisMonth'), [])
+  const [preset, setPreset] = useState<string>('thisMonth')
+  const [from, setFrom] = useState(initial.from)
+  const [to, setTo] = useState(initial.to)
+  const [status, setStatus] = useState<'all' | 'pending' | 'paid'>('all')
+  const [source, setSource] = useState<'all' | 'os' | 'resale'>('all')
+  const [items, setItems] = useState<StaffCommissionItem[]>([])
+  const [totals, setTotals] = useState<Totals>({
+    pendingCents: 0,
+    paidCents: 0,
+    totalCents: 0,
+    count: 0,
+  })
+  const [isLoading, setIsLoading] = useState(true)
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(() => new Set())
+
+  const load = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const params = new URLSearchParams({
+        from,
+        to,
+        status,
+        source,
+      })
+      const res = await portalFetch(`/api/portal/admin/finance/commissions?${params}`)
+      const data = (await res?.json().catch(() => null)) as ListResponse | null
+      if (!res?.ok || data?.ok !== true) {
+        throw new Error(data?.error || 'Não foi possível carregar as comissões.')
+      }
+      setItems(data.items ?? [])
+      setTotals(
+        data.totals ?? {
+          pendingCents: 0,
+          paidCents: 0,
+          totalCents: 0,
+          count: 0,
+        },
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erro ao carregar.'
+      toast({ variant: 'destructive', title: 'Erro', description: message })
+      setItems([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [from, to, status, source])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  function handlePresetChange (next: string) {
+    setPreset(next)
+    if (next !== 'custom') {
+      const range = buildRange(next)
+      setFrom(range.from)
+      setTo(range.to)
+    }
+  }
+
+  async function togglePaid (item: StaffCommissionItem, nextPaid: boolean) {
+    if (togglingIds.has(item.id) || item.isPaid === nextPaid) return
+
+    const snapshot = item
+    const optimisticPaidAt = nextPaid ? new Date().toISOString() : null
+    const leavesCurrentFilter =
+      (status === 'pending' && nextPaid) || (status === 'paid' && !nextPaid)
+
+    setTogglingIds((prev) => {
+      const next = new Set(prev)
+      next.add(item.id)
+      return next
+    })
+
+    setItems((prev) => {
+      if (leavesCurrentFilter) return prev.filter((row) => row.id !== item.id)
+      return prev.map((row) =>
+        row.id === item.id
+          ? { ...row, isPaid: nextPaid, paidAt: optimisticPaidAt }
+          : row,
+      )
+    })
+
+    setTotals((prev) => {
+      const delta = item.amountCents
+      if (leavesCurrentFilter) {
+        return {
+          ...prev,
+          count: Math.max(0, prev.count - 1),
+          pendingCents: nextPaid
+            ? Math.max(0, prev.pendingCents - delta)
+            : prev.pendingCents,
+          paidCents: nextPaid
+            ? prev.paidCents
+            : Math.max(0, prev.paidCents - delta),
+          totalCents: Math.max(0, prev.totalCents - delta),
+        }
+      }
+      if (nextPaid) {
+        return {
+          ...prev,
+          pendingCents: Math.max(0, prev.pendingCents - delta),
+          paidCents: prev.paidCents + delta,
+        }
+      }
+      return {
+        ...prev,
+        pendingCents: prev.pendingCents + delta,
+        paidCents: Math.max(0, prev.paidCents - delta),
+      }
+    })
+
+    try {
+      const res = await portalFetch('/api/portal/admin/finance/commissions', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          source: item.source,
+          sourceId: item.sourceId,
+          paid: nextPaid,
+        }),
+      })
+      const data = await res?.json().catch(() => null)
+      if (!res?.ok || data?.ok !== true) {
+        throw new Error(data?.error || 'Não foi possível atualizar.')
+      }
+
+      if (!leavesCurrentFilter && typeof data.paidAt === 'string') {
+        setItems((prev) =>
+          prev.map((row) =>
+            row.id === item.id
+              ? { ...row, isPaid: nextPaid, paidAt: data.paidAt }
+              : row,
+          ),
+        )
+      }
+    } catch (err) {
+      setItems((prev) => {
+        if (leavesCurrentFilter) {
+          if (prev.some((row) => row.id === snapshot.id)) return prev
+          return [...prev, snapshot].sort((a, b) => {
+            if (a.earnedAt !== b.earnedAt) return b.earnedAt.localeCompare(a.earnedAt)
+            return b.amountCents - a.amountCents
+          })
+        }
+        return prev.map((row) => (row.id === snapshot.id ? snapshot : row))
+      })
+
+      setTotals((prev) => {
+        const delta = snapshot.amountCents
+        if (leavesCurrentFilter) {
+          return {
+            ...prev,
+            count: prev.count + 1,
+            pendingCents: snapshot.isPaid
+              ? prev.pendingCents
+              : prev.pendingCents + delta,
+            paidCents: snapshot.isPaid
+              ? prev.paidCents + delta
+              : prev.paidCents,
+            totalCents: prev.totalCents + delta,
+          }
+        }
+        if (nextPaid) {
+          return {
+            ...prev,
+            pendingCents: prev.pendingCents + delta,
+            paidCents: Math.max(0, prev.paidCents - delta),
+          }
+        }
+        return {
+          ...prev,
+          pendingCents: Math.max(0, prev.pendingCents - delta),
+          paidCents: prev.paidCents + delta,
+        }
+      })
+
+      const message = err instanceof Error ? err.message : 'Erro ao atualizar.'
+      toast({ variant: 'destructive', title: 'Erro', description: message })
+    } finally {
+      setTogglingIds((prev) => {
+        const next = new Set(prev)
+        next.delete(item.id)
+        return next
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="p-5">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Percent className="h-5 w-5" aria-hidden />
+            Comissões
+          </CardTitle>
+          <CardDescription>
+            Comissões de OS finalizadas e aparelhos vendidos. Marque como paga quando o
+            colaborador receber.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 p-5 pt-0">
+          <div className="flex flex-col gap-3 lg:flex-row lg:flex-wrap lg:items-end">
+            <div className="space-y-1.5">
+              <Label>Período</Label>
+              <Select value={preset} onValueChange={handlePresetChange}>
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRESETS.map((p) => (
+                    <SelectItem key={p.from} value={p.from}>
+                      {p.to}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {preset === 'custom' ? (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="comm-from">De</Label>
+                  <Input
+                    id="comm-from"
+                    type="date"
+                    value={from}
+                    onChange={(e) => setFrom(e.target.value)}
+                    className="w-[160px]"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="comm-to">Até</Label>
+                  <Input
+                    id="comm-to"
+                    type="date"
+                    value={to}
+                    onChange={(e) => setTo(e.target.value)}
+                    className="w-[160px]"
+                  />
+                </div>
+              </>
+            ) : null}
+            <div className="space-y-1.5">
+              <Label>Status</Label>
+              <Select
+                value={status}
+                onValueChange={(v: 'all' | 'pending' | 'paid') => setStatus(v)}
+              >
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todas</SelectItem>
+                  <SelectItem value="pending">Pendentes</SelectItem>
+                  <SelectItem value="paid">Pagas</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Origem</Label>
+              <Select
+                value={source}
+                onValueChange={(v: 'all' | 'os' | 'resale') => setSource(v)}
+              >
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todas</SelectItem>
+                  <SelectItem value="os">Ordens de serviço</SelectItem>
+                  <SelectItem value="resale">Aparelhos</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void load()}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
+              <span className="ml-2">Atualizar</span>
+            </Button>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-md border bg-muted/20 px-3 py-2">
+              <p className="text-xs text-muted-foreground">Pendentes</p>
+              <p className="font-mono text-base font-semibold tabular-nums text-amber-700 dark:text-amber-400">
+                R$ {maskedFromCents(totals.pendingCents)}
+              </p>
+            </div>
+            <div className="rounded-md border bg-muted/20 px-3 py-2">
+              <p className="text-xs text-muted-foreground">Pagas</p>
+              <p className="font-mono text-base font-semibold tabular-nums text-emerald-600 dark:text-emerald-400">
+                R$ {maskedFromCents(totals.paidCents)}
+              </p>
+            </div>
+            <div className="rounded-md border bg-muted/20 px-3 py-2">
+              <p className="text-xs text-muted-foreground">Total no período</p>
+              <p className="font-mono text-base font-semibold tabular-nums">
+                R$ {maskedFromCents(totals.totalCents)}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Carregando comissões…
+            </div>
+          ) : items.length === 0 ? (
+            <p className="px-5 py-12 text-center text-sm text-muted-foreground">
+              Nenhuma comissão encontrada neste período.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[100px]">Data</TableHead>
+                    <TableHead className="w-[90px]">Origem</TableHead>
+                    <TableHead>Referência</TableHead>
+                    <TableHead>Colaborador</TableHead>
+                    <TableHead className="text-right">Valor</TableHead>
+                    <TableHead className="w-[110px]">Status</TableHead>
+                    <TableHead className="w-[90px] text-center">Pago</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {items.map((item) => {
+                    const busy = togglingIds.has(item.id)
+                    return (
+                      <TableRow key={item.id}>
+                        <TableCell className="whitespace-nowrap text-sm">
+                          {formatDateBr(item.earnedAt)}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">{sourceLabel(item.source)}</Badge>
+                        </TableCell>
+                        <TableCell className="max-w-[280px]">
+                          <Link
+                            href={item.href}
+                            className="line-clamp-2 text-sm font-medium text-primary underline-offset-2 hover:underline"
+                          >
+                            {item.label}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="text-sm">{item.userDisplayName}</TableCell>
+                        <TableCell className="text-right font-mono tabular-nums text-sm">
+                          R$ {maskedFromCents(item.amountCents)}
+                        </TableCell>
+                        <TableCell>
+                          {item.isPaid ? (
+                            <Badge className="bg-emerald-600 hover:bg-emerald-600">Paga</Badge>
+                          ) : (
+                            <Badge variant="secondary">Pendente</Badge>
+                          )}
+                          {item.isPaid && item.paidAt ? (
+                            <p className="mt-1 text-[11px] text-muted-foreground">
+                              {format(new Date(item.paidAt), 'dd/MM/yyyy', { locale: ptBR })}
+                            </p>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <div className="flex items-center justify-center">
+                            {busy ? (
+                              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                            ) : (
+                              <Checkbox
+                                checked={item.isPaid}
+                                onCheckedChange={(v) => {
+                                  void togglePaid(item, v === true)
+                                }}
+                                aria-label={
+                                  item.isPaid
+                                    ? 'Desmarcar comissão como paga'
+                                    : 'Marcar comissão como paga'
+                                }
+                              />
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(portal)/portal/financeiro/comissoes/page.tsx
+++ b/src/app/(portal)/portal/financeiro/comissoes/page.tsx
@@ -1,0 +1,7 @@
+import { FinanceiroComissoesClient } from './FinanceiroComissoesClient'
+
+export const dynamic = 'force-dynamic'
+
+export default function FinanceiroComissoesPage () {
+  return <FinanceiroComissoesClient />
+}

--- a/src/app/(portal)/portal/financeiro/layout.tsx
+++ b/src/app/(portal)/portal/financeiro/layout.tsx
@@ -17,7 +17,7 @@ export default async function FinanceiroLayout({
       <div>
         <h1 className="text-2xl font-bold">Financeiro</h1>
         <p className="text-sm text-muted-foreground">
-          Entradas, saídas e saldos por conta. Apenas administradores.
+          Entradas, saídas, comissões e saldos por conta. Apenas administradores.
         </p>
       </div>
 

--- a/src/app/(portal)/portal/ordens/[numero]/OrdemDetalhePageContent.tsx
+++ b/src/app/(portal)/portal/ordens/[numero]/OrdemDetalhePageContent.tsx
@@ -73,6 +73,7 @@ type Props = {
 	sellerOptions: SellerOption[]
 	entryPhotoCount: number
 	exitPhotoCount: number
+	assistancePhotoCount: number
 	role: string
 	isAdmin: boolean
 	/** Abre o modal avançado de serviços quando `?servicesModal=1` */
@@ -96,6 +97,7 @@ export function OrdemDetalhePageContent (props: Props) {
 		sellerOptions,
 		entryPhotoCount,
 		exitPhotoCount,
+		assistancePhotoCount,
 		role,
 		isAdmin,
 		openServicesModalInitially,
@@ -257,8 +259,11 @@ export function OrdemDetalhePageContent (props: Props) {
 						<Card>
 							<CardHeader className="p-5">
 								<CardTitle>Informações sobre a assistência</CardTitle>
+								<CardDescription>
+									Comentários e fotos visíveis para o cliente no link público da OS.
+								</CardDescription>
 							</CardHeader>
-							<CardContent className="p-5 pt-0">
+							<CardContent className="space-y-6 p-5 pt-0">
 								<OrderAssistanceChat
 									orderId={order.id}
 									assistanceAiContext={{
@@ -266,6 +271,13 @@ export function OrdemDetalhePageContent (props: Props) {
 										customerDescription: String(order.customer_description || ''),
 										receivingNotes: String(order.receiving_notes || ''),
 									}}
+								/>
+								<OrderEntryPhotos
+									orderId={order.id}
+									portalPathSegment={getOrdemPortalPathSegment(order)}
+									initialPhotoCount={assistancePhotoCount}
+									disabled={formDisabled}
+									photoStage="assistance"
 								/>
 							</CardContent>
 						</Card>

--- a/src/app/(portal)/portal/ordens/[numero]/OrderEntryPhotos.tsx
+++ b/src/app/(portal)/portal/ordens/[numero]/OrderEntryPhotos.tsx
@@ -32,7 +32,7 @@ export type EntryPhotoItem = {
 	created_at: string;
 };
 
-export type OrderPhotosStage = "entry" | "exit";
+export type OrderPhotosStage = "entry" | "exit" | "assistance";
 
 const PHOTO_STAGE_CONFIG: Record<
 	OrderPhotosStage,
@@ -79,6 +79,21 @@ const PHOTO_STAGE_CONFIG: Record<
 			"A foto de saída foi removida e a alteração já está salva.",
 		ariaAdd: "Adicionar fotos de saída",
 	},
+	assistance: {
+		apiPath: "assistance-photos",
+		queryOpen: "addAssistancePhotos",
+		labelRow: "Fotos da assistência",
+		modalTitle: "Fotos da assistência",
+		modalDesc:
+			"Adicione fotos do processo de assistência. Elas ficam visíveis para o cliente no link público da OS. No celular, escaneie o QR code para abrir esta tela e enviar fotos da câmera.",
+		toastSavedTitle: "Fotos da assistência salvas",
+		toastSavedDesc:
+			"As fotos da assistência foram adicionadas e já estão salvas.",
+		toastDeletedTitle: "Foto da assistência excluída",
+		toastDeletedDesc:
+			"A foto da assistência foi removida e a alteração já está salva.",
+		ariaAdd: "Adicionar fotos da assistência",
+	},
 };
 
 type OrderEntryPhotosProps = {
@@ -89,7 +104,7 @@ type OrderEntryPhotosProps = {
 	/** Quantidade de fotos vinda do servidor (evita request extra no mount) */
 	initialPhotoCount?: number | null;
 	disabled?: boolean;
-	/** `entry` = recebimento; `saída` = bucket e API próprios */
+	/** `entry` / `exit` / `assistance` = buckets e APIs próprios */
 	photoStage?: OrderPhotosStage;
 };
 

--- a/src/app/(portal)/portal/ordens/[numero]/page.tsx
+++ b/src/app/(portal)/portal/ordens/[numero]/page.tsx
@@ -121,7 +121,7 @@ export default async function OrdemDetalhePage ({
 		(order as { seller_user_id?: string | null }).seller_user_id ?? null
 	const isAdmin = role === 'admin' || role === 'platform_admin'
 
-	const [sellerUser, staffAdminUsers, entryPhotoCountRes, exitPhotoCountRes] = await Promise.all([
+	const [sellerUser, staffAdminUsers, entryPhotoCountRes, exitPhotoCountRes, assistancePhotoCountRes] = await Promise.all([
 		sellerUserId
 			? supabase
 				.from('users')
@@ -142,9 +142,14 @@ export default async function OrdemDetalhePage ({
 			.from('service_order_exit_photos')
 			.select('*', { count: 'exact', head: true })
 			.eq('service_order_id', order.id),
+		supabase
+			.from('service_order_assistance_photos')
+			.select('*', { count: 'exact', head: true })
+			.eq('service_order_id', order.id),
 	])
 	const entryPhotoCount = entryPhotoCountRes?.count ?? 0
 	const exitPhotoCount = exitPhotoCountRes?.count ?? 0
+	const assistancePhotoCount = assistancePhotoCountRes?.count ?? 0
 
 	const seller = sellerUser.data
 	const sellerDisplayName = seller
@@ -199,6 +204,7 @@ export default async function OrdemDetalhePage ({
 			sellerOptions={sellerOptions}
 			entryPhotoCount={entryPhotoCount}
 			exitPhotoCount={exitPhotoCount}
+			assistancePhotoCount={assistancePhotoCount}
 			role={role}
 			isAdmin={isAdmin}
 			openServicesModalInitially={openServicesModalInitially}

--- a/src/app/api/portal/admin/finance/commissions/route.ts
+++ b/src/app/api/portal/admin/finance/commissions/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth/portal-api'
+import {
+  listStaffCommissions,
+  setStaffCommissionPaid,
+  type StaffCommissionSource,
+} from '@/lib/finance/staff-commissions'
+import { parseOptionalUuid } from '@/lib/utils/optional-uuid'
+
+function ymd (raw: string | null): string | null {
+  const v = String(raw || '').trim().slice(0, 10)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) return null
+  return v
+}
+
+function currentMonthRange (): { from: string; to: string } {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = now.getMonth()
+  const d = now.getDate()
+  const fmt = (date: Date) => date.toISOString().slice(0, 10)
+  return { from: fmt(new Date(y, m, 1)), to: fmt(new Date(y, m, d)) }
+}
+
+export async function GET (request: NextRequest) {
+  const auth = await requireAdmin()
+  if (auth.ok === false) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  const url = new URL(request.url)
+  const fallback = currentMonthRange()
+  const from = ymd(url.searchParams.get('from')) || fallback.from
+  const to = ymd(url.searchParams.get('to')) || fallback.to
+  const statusRaw = String(url.searchParams.get('status') || 'all').trim()
+  const sourceRaw = String(url.searchParams.get('source') || 'all').trim()
+  const status =
+    statusRaw === 'pending' || statusRaw === 'paid' ? statusRaw : 'all'
+  const source =
+    sourceRaw === 'os' || sourceRaw === 'resale' ? sourceRaw : 'all'
+
+  try {
+    const items = await listStaffCommissions(auth.supabase, {
+      organizationId: auth.organizationId,
+      from,
+      to,
+      status,
+      source,
+    })
+
+    const pendingCents = items
+      .filter((i) => !i.isPaid)
+      .reduce((sum, i) => sum + i.amountCents, 0)
+    const paidCents = items
+      .filter((i) => i.isPaid)
+      .reduce((sum, i) => sum + i.amountCents, 0)
+
+    return NextResponse.json({
+      ok: true,
+      from,
+      to,
+      items,
+      totals: {
+        pendingCents,
+        paidCents,
+        totalCents: pendingCents + paidCents,
+        count: items.length,
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'list_failed'
+    console.error('[finance/commissions GET]', message)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}
+
+export async function PATCH (request: NextRequest) {
+  const auth = await requireAdmin()
+  if (auth.ok === false) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  const body = await request.json().catch(() => null)
+  const sourceRaw = String(body?.source || '').trim()
+  const source: StaffCommissionSource | null =
+    sourceRaw === 'os' || sourceRaw === 'resale' ? sourceRaw : null
+  const sourceId = parseOptionalUuid(String(body?.sourceId || body?.source_id || ''))
+  const paid = body?.paid === true || body?.paid === '1' || body?.paid === 1
+
+  if (!source || !sourceId) {
+    return NextResponse.json({ ok: false, error: 'invalid_payload' }, { status: 400 })
+  }
+
+  try {
+    const result = await setStaffCommissionPaid(
+      auth.supabase,
+      auth.organizationId,
+      source,
+      sourceId,
+      paid,
+    )
+    return NextResponse.json({
+      ok: true,
+      source,
+      sourceId,
+      paid,
+      paidAt: result.paidAt,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'update_failed'
+    if (message === 'not_found') {
+      return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+    }
+    console.error('[finance/commissions PATCH]', message)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}

--- a/src/app/api/portal/admin/service-order-photos/[photoId]/route.ts
+++ b/src/app/api/portal/admin/service-order-photos/[photoId]/route.ts
@@ -7,7 +7,7 @@ import {
 import { parseOptionalUuid } from '@/lib/utils/optional-uuid'
 
 function parsePhotoKind (value: string | null): ServiceOrderPhotoKind | null {
-  if (value === 'entry' || value === 'exit') return value
+  if (value === 'entry' || value === 'exit' || value === 'assistance') return value
   return null
 }
 

--- a/src/app/api/portal/device-brands/[id]/route.ts
+++ b/src/app/api/portal/device-brands/[id]/route.ts
@@ -1,54 +1,80 @@
 import { NextResponse } from 'next/server'
 import { requireStaffOrAdmin } from '@/lib/auth/portal-api'
+import { parseOptionalUuid } from '@/lib/utils/optional-uuid'
 
-function cleanText(value: string) {
+function cleanText (value: string) {
   return String(value || '').trim()
 }
 
-export async function GET() {
+export async function PATCH (
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const auth = await requireStaffOrAdmin()
   if (auth.ok === false) {
     return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
   }
-  const { data, error } = await auth.supabase
-    .from('device_brands')
-    .select('id, name')
-    .order('name', { ascending: true })
-  if (error) {
-    console.error('[device-brands GET]', error)
-    const message = process.env.NODE_ENV === 'development' ? error.message : 'db_error'
-    return NextResponse.json({ ok: false, error: 'db_error', message }, { status: 500 })
-  }
-  return NextResponse.json({ ok: true, deviceBrands: data || [] })
-}
-
-export async function POST(request: Request) {
-  const auth = await requireStaffOrAdmin()
-  if (auth.ok === false) {
-    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  const { id: rawId } = await params
+  const id = parseOptionalUuid(rawId)
+  if (!id) {
+    return NextResponse.json({ ok: false, error: 'invalid_id' }, { status: 400 })
   }
   const body = await request.json().catch(() => null)
-  const name = cleanText(body?.name)
+  const name = cleanText(String(body?.name || ''))
   if (!name) {
     return NextResponse.json({ ok: false, error: 'invalid_payload' }, { status: 400 })
   }
-  const { data: inserted, error } = await auth.supabase
+
+  const { data, error } = await auth.supabase
     .from('device_brands')
-    .insert({ name })
-    .select('id, name')
-    .single()
+    .update({ name })
+    .eq('id', id)
+    .eq('organization_id', auth.organizationId)
+    .select('id, name, organization_id')
+    .maybeSingle()
+
   if (error) {
     if (error.code === '23505') {
-      const { data: existing } = await auth.supabase
-        .from('device_brands')
-        .select('id, name')
-        .eq('name', name)
-        .maybeSingle()
-      if (existing) {
-        return NextResponse.json({ ok: true, deviceBrand: existing, existed: true })
-      }
+      return NextResponse.json({ ok: false, error: 'duplicate_name' }, { status: 409 })
     }
+    console.error('[device-brands PATCH]', error)
     return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })
   }
-  return NextResponse.json({ ok: true, deviceBrand: inserted, existed: false })
+  if (!data) {
+    return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+  }
+  return NextResponse.json({ ok: true, deviceBrand: data })
+}
+
+export async function DELETE (
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireStaffOrAdmin()
+  if (auth.ok === false) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+  const { id: rawId } = await params
+  const id = parseOptionalUuid(rawId)
+  if (!id) {
+    return NextResponse.json({ ok: false, error: 'invalid_id' }, { status: 400 })
+  }
+
+  const { data: deleted, error } = await auth.supabase
+    .from('device_brands')
+    .delete()
+    .eq('id', id)
+    .eq('organization_id', auth.organizationId)
+    .select('id')
+    .maybeSingle()
+
+  if (error) {
+    console.error('[device-brands DELETE]', error)
+    const message = process.env.NODE_ENV === 'development' ? error.message : undefined
+    return NextResponse.json({ ok: false, error: 'db_error', message }, { status: 500 })
+  }
+  if (!deleted) {
+    return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+  }
+  return NextResponse.json({ ok: true })
 }

--- a/src/app/api/portal/device-brands/route.ts
+++ b/src/app/api/portal/device-brands/route.ts
@@ -1,29 +1,51 @@
 import { NextResponse } from 'next/server'
 import { requireStaffOrAdmin } from '@/lib/auth/portal-api'
+import { CONECTIZE_HOST_ORGANIZATION_ID } from '@/lib/organizations/constants'
+import {
+  deviceCatalogOrganizationIds,
+  preferHostCatalogRows,
+} from '@/lib/organizations/device-catalog'
 
-function cleanText(value: string) {
+function cleanText (value: string) {
   return String(value || '').trim()
 }
 
-export async function GET() {
+type BrandRow = {
+  id: string
+  name: string
+  organization_id: string
+}
+
+export async function GET () {
   const auth = await requireStaffOrAdmin()
   if (auth.ok === false) {
     return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
   }
+
+  const orgIds = deviceCatalogOrganizationIds(auth.organizationId)
   const { data, error } = await auth.supabase
     .from('device_brands')
-    .select('id, name')
-    .eq('organization_id', auth.organizationId)
+    .select('id, name, organization_id')
+    .in('organization_id', orgIds)
     .order('name', { ascending: true })
+
   if (error) {
     console.error('[device-brands GET]', error)
     const message = process.env.NODE_ENV === 'development' ? error.message : 'db_error'
     return NextResponse.json({ ok: false, error: 'db_error', message }, { status: 500 })
   }
-  return NextResponse.json({ ok: true, deviceBrands: data || [] })
+
+  const deviceBrands = preferHostCatalogRows((data || []) as BrandRow[], (row) => row.name)
+    .sort((a, b) => a.name.localeCompare(b.name, 'pt-BR', { sensitivity: 'base' }))
+
+  return NextResponse.json({
+    ok: true,
+    deviceBrands,
+    currentOrganizationId: auth.organizationId,
+  })
 }
 
-export async function POST(request: Request) {
+export async function POST (request: Request) {
   const auth = await requireStaffOrAdmin()
   if (auth.ok === false) {
     return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
@@ -33,16 +55,41 @@ export async function POST(request: Request) {
   if (!name) {
     return NextResponse.json({ ok: false, error: 'invalid_payload' }, { status: 400 })
   }
+
+  // Reutiliza marca do host se já existir (evita duplicar catálogo compartilhado)
+  if (auth.organizationId !== CONECTIZE_HOST_ORGANIZATION_ID) {
+    const { data: hostExisting } = await auth.supabase
+      .from('device_brands')
+      .select('id, name, organization_id')
+      .eq('organization_id', CONECTIZE_HOST_ORGANIZATION_ID)
+      .ilike('name', name)
+      .maybeSingle()
+    if (hostExisting?.id && cleanText(hostExisting.name).toLowerCase() === name.toLowerCase()) {
+      return NextResponse.json({ ok: true, deviceBrand: hostExisting, existed: true })
+    }
+  }
+
+  const { data: orgExisting } = await auth.supabase
+    .from('device_brands')
+    .select('id, name, organization_id')
+    .eq('organization_id', auth.organizationId)
+    .eq('name', name)
+    .maybeSingle()
+  if (orgExisting?.id) {
+    return NextResponse.json({ ok: true, deviceBrand: orgExisting, existed: true })
+  }
+
   const { data: inserted, error } = await auth.supabase
     .from('device_brands')
     .insert({ name, organization_id: auth.organizationId })
-    .select('id, name')
+    .select('id, name, organization_id')
     .single()
+
   if (error) {
     if (error.code === '23505') {
       const { data: existing } = await auth.supabase
         .from('device_brands')
-        .select('id, name')
+        .select('id, name, organization_id')
         .eq('organization_id', auth.organizationId)
         .eq('name', name)
         .maybeSingle()

--- a/src/app/api/portal/device-models/[id]/route.ts
+++ b/src/app/api/portal/device-models/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { requireStaffOrAdmin } from '@/lib/auth/portal-api'
+import { deviceCatalogOrganizationIds } from '@/lib/organizations/device-catalog'
 import { parseOptionalUuid } from '@/lib/utils/optional-uuid'
 
 function cleanText (value: string) {
@@ -35,7 +36,7 @@ export async function PATCH (
 		.from('device_types')
 		.select('id, name, device_brands ( id, name )')
 		.eq('id', deviceTypeId)
-		.eq('organization_id', auth.organizationId)
+		.in('organization_id', deviceCatalogOrganizationIds(auth.organizationId))
 		.maybeSingle()
 	if (typeErr || !typeRow) {
 		return NextResponse.json({ ok: false, error: 'invalid_device_type' }, { status: 400 })
@@ -53,7 +54,7 @@ export async function PATCH (
 		.update({ device_type_id: deviceTypeId, model })
 		.eq('id', id)
 		.eq('organization_id', auth.organizationId)
-		.select('id, model, device_type_id')
+		.select('id, model, device_type_id, organization_id')
 		.maybeSingle()
 
 	if (error) {
@@ -76,6 +77,7 @@ export async function PATCH (
 			id: updated.id,
 			model: updated.model,
 			device_type_id: updated.device_type_id,
+			organization_id: updated.organization_id,
 			brand: brandName,
 			device_type: deviceTypeName,
 		},

--- a/src/app/api/portal/device-models/route.ts
+++ b/src/app/api/portal/device-models/route.ts
@@ -1,13 +1,18 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { NextResponse } from 'next/server'
 import { requireStaffOrAdmin } from '@/lib/auth/portal-api'
+import { CONECTIZE_HOST_ORGANIZATION_ID } from '@/lib/organizations/constants'
+import {
+	deviceCatalogOrganizationIds,
+	preferHostCatalogRows,
+} from '@/lib/organizations/device-catalog'
 
-function cleanText(value: string) {
+function cleanText (value: string) {
 	return String(value || '').trim()
 }
 
 /** Evita `%` / `_` literais quebrarem o padrão do `ilike`. */
-function escapeIlikePattern(value: string) {
+function escapeIlikePattern (value: string) {
 	return String(value || '')
 		.replace(/\\/g, '\\\\')
 		.replace(/%/g, '\\%')
@@ -22,10 +27,11 @@ type ModelRow = {
 	id: string
 	model?: string | null
 	device_type_id?: string
+	organization_id?: string | null
 	device_types?: Dt | Dt[] | null
 }
 
-function mapDeviceModelRows(data: ModelRow[] | null) {
+function mapDeviceModelRows (data: ModelRow[] | null) {
 	return (data || []).map((row) => {
 		const dt = Array.isArray(row.device_types) ? row.device_types[0] : row.device_types
 		const br = dt?.device_brands
@@ -34,6 +40,7 @@ function mapDeviceModelRows(data: ModelRow[] | null) {
 			id: row.id,
 			model: row.model,
 			device_type_id: row.device_type_id,
+			organization_id: row.organization_id ?? null,
 			brand: brand?.name ?? null,
 			device_type: dt?.name ?? null,
 		}
@@ -41,14 +48,14 @@ function mapDeviceModelRows(data: ModelRow[] | null) {
 }
 
 const DEVICE_MODEL_LIST_SELECT =
-	'id, model, device_type_id, device_types ( id, name, device_brands ( id, name ) )'
+	'id, model, device_type_id, organization_id, device_types ( id, name, device_brands ( id, name ) )'
 
 /** Palavras comuns que sozinhas geram ruído em `ilike` (AND). */
 const MODEL_SEARCH_STOPWORDS = new Set([
 	'de', 'da', 'do', 'para', 'com', 'sem', 'celular', 'smartphone', 'aparelho', 'original',
 ])
 
-function modelSearchTokens(raw: string): string[] {
+function modelSearchTokens (raw: string): string[] {
 	const parts = String(raw || '')
 		.trim()
 		.toLowerCase()
@@ -62,9 +69,9 @@ function modelSearchTokens(raw: string): string[] {
  * Busca modelos por texto: frase inteira na coluna `model`, AND por tokens (ex.: iphone + 11),
  * string sem espaços, e OR modelo/marca (marca vem do join).
  */
-async function searchDeviceModelsByText(
+async function searchDeviceModelsByText (
 	supabase: SupabaseClient,
-	organizationId: string,
+	organizationIds: string[],
 	q: string,
 	deviceTypeId: string,
 	limit: number,
@@ -86,7 +93,7 @@ async function searchDeviceModelsByText(
 
 	const base = () => {
 		let qb = supabase.from('device_models').select(DEVICE_MODEL_LIST_SELECT)
-		qb = qb.eq('organization_id', organizationId)
+		qb = qb.in('organization_id', organizationIds)
 		if (deviceTypeId) qb = qb.eq('device_type_id', deviceTypeId)
 		return qb
 	}
@@ -117,9 +124,9 @@ async function searchDeviceModelsByText(
 	let qb4 = supabase
 		.from('device_models')
 		.select(
-			'id, model, device_type_id, device_types!inner ( id, name, device_brands!inner ( id, name ) )',
+			'id, model, device_type_id, organization_id, device_types!inner ( id, name, device_brands!inner ( id, name ) )',
 		)
-	qb4 = qb4.eq('organization_id', organizationId)
+	qb4 = qb4.in('organization_id', organizationIds)
 	if (deviceTypeId) qb4 = qb4.eq('device_type_id', deviceTypeId)
 	const { data: d4, error: e4 } = await qb4
 		.or(`model.ilike.%${safe}%,device_types.device_brands.name.ilike.%${safe}%`)
@@ -142,18 +149,24 @@ async function searchDeviceModelsByText(
 		merged = merged.filter((row) => narrowed.has(String(row.id)))
 	}
 
+	merged = preferHostCatalogRows(
+		merged,
+		(row) => `${row.device_type_id || ''}::${row.model || ''}`,
+	)
+
 	merged.sort((a, b) =>
 		String(a.model || '').localeCompare(String(b.model || ''), 'pt-BR', { sensitivity: 'base' }),
 	)
 	return merged.slice(0, limit)
 }
 
-export async function GET(request: Request) {
+export async function GET (request: Request) {
 	const auth = await requireStaffOrAdmin()
 	if (auth.ok === false) {
 		return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
 	}
 
+	const orgIds = deviceCatalogOrganizationIds(auth.organizationId)
 	const url = new URL(request.url)
 	const idsParam = cleanText(String(url.searchParams.get('ids') || ''))
 
@@ -172,8 +185,8 @@ export async function GET(request: Request) {
 
 		const { data, error } = await auth.supabase
 			.from('device_models')
-			.select('id, model, device_type_id, device_types ( id, name, device_brands ( id, name ) )')
-			.eq('organization_id', auth.organizationId)
+			.select(DEVICE_MODEL_LIST_SELECT)
+			.in('organization_id', orgIds)
 			.in('id', unique)
 
 		if (error) {
@@ -181,7 +194,11 @@ export async function GET(request: Request) {
 		}
 
 		const rows = mapDeviceModelRows(data as ModelRow[])
-		const res = NextResponse.json({ ok: true, deviceModels: rows })
+		const res = NextResponse.json({
+			ok: true,
+			deviceModels: rows,
+			currentOrganizationId: auth.organizationId,
+		})
 		res.headers.set('Cache-Control', 'private, max-age=300')
 		return res
 	}
@@ -196,15 +213,15 @@ export async function GET(request: Request) {
 	let rows: ReturnType<typeof mapDeviceModelRows>
 
 	if (q) {
-		const merged = await searchDeviceModelsByText(auth.supabase, auth.organizationId, q, deviceTypeId, limit)
+		const merged = await searchDeviceModelsByText(auth.supabase, orgIds, q, deviceTypeId, limit)
 		rows = mapDeviceModelRows(merged)
 	} else {
 		const query = auth.supabase
 			.from('device_models')
 			.select(DEVICE_MODEL_LIST_SELECT)
-			.eq('organization_id', auth.organizationId)
+			.in('organization_id', orgIds)
 			.order('model', { ascending: true })
-			.limit(limit)
+			.limit(Math.min(limit * 2, 8000))
 
 		if (deviceTypeId) query.eq('device_type_id', deviceTypeId)
 
@@ -213,15 +230,28 @@ export async function GET(request: Request) {
 			return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })
 		}
 
-		rows = mapDeviceModelRows(data as ModelRow[])
+		const deduped = preferHostCatalogRows(
+			(data || []) as ModelRow[],
+			(row) => `${row.device_type_id || ''}::${row.model || ''}`,
+		)
+			.sort((a, b) =>
+				String(a.model || '').localeCompare(String(b.model || ''), 'pt-BR', { sensitivity: 'base' }),
+			)
+			.slice(0, limit)
+
+		rows = mapDeviceModelRows(deduped)
 	}
 
-	const res = NextResponse.json({ ok: true, deviceModels: rows })
+	const res = NextResponse.json({
+		ok: true,
+		deviceModels: rows,
+		currentOrganizationId: auth.organizationId,
+	})
 	res.headers.set('Cache-Control', 'private, max-age=300')
 	return res
 }
 
-export async function POST(request: Request) {
+export async function POST (request: Request) {
 	const auth = await requireStaffOrAdmin()
 	if (auth.ok === false) {
 		return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
@@ -235,13 +265,17 @@ export async function POST(request: Request) {
 		return NextResponse.json({ ok: false, error: 'invalid_payload' }, { status: 400 })
 	}
 
+	const orgIds = deviceCatalogOrganizationIds(auth.organizationId)
 	const { data: typeRow } = await auth.supabase
 		.from('device_types')
-		.select('id, name, device_brands ( id, name )')
+		.select('id, name, organization_id, device_brands ( id, name )')
 		.eq('id', deviceTypeId)
-		.eq('organization_id', auth.organizationId)
+		.in('organization_id', orgIds)
 		.maybeSingle()
-	const tr = typeRow as { name?: string | null; device_brands?: { name?: string | null } | { name?: string | null }[] | null } | null
+	const tr = typeRow as {
+		name?: string | null
+		device_brands?: { name?: string | null } | { name?: string | null }[] | null
+	} | null
 	const db = tr?.device_brands
 	const brandName = (Array.isArray(db) ? db[0]?.name : db?.name) ?? ''
 	const deviceTypeName = tr?.name ?? ''
@@ -249,9 +283,33 @@ export async function POST(request: Request) {
 		return NextResponse.json({ ok: false, error: 'invalid_device_type' }, { status: 400 })
 	}
 
+	if (auth.organizationId !== CONECTIZE_HOST_ORGANIZATION_ID) {
+		const { data: hostExisting } = await auth.supabase
+			.from('device_models')
+			.select('id, model, device_type_id, organization_id')
+			.eq('organization_id', CONECTIZE_HOST_ORGANIZATION_ID)
+			.eq('device_type_id', deviceTypeId)
+			.eq('model', model)
+			.maybeSingle()
+		if (hostExisting?.id) {
+			return NextResponse.json({
+				ok: true,
+				deviceModel: {
+					id: hostExisting.id,
+					model: hostExisting.model,
+					device_type_id: hostExisting.device_type_id,
+					organization_id: hostExisting.organization_id,
+					brand: brandName,
+					device_type: deviceTypeName,
+				},
+				existed: true,
+			})
+		}
+	}
+
 	const { data: existing } = await auth.supabase
 		.from('device_models')
-		.select('id, model, device_type_id')
+		.select('id, model, device_type_id, organization_id')
 		.eq('organization_id', auth.organizationId)
 		.eq('device_type_id', deviceTypeId)
 		.eq('model', model)
@@ -260,7 +318,14 @@ export async function POST(request: Request) {
 	if (existing?.id) {
 		return NextResponse.json({
 			ok: true,
-			deviceModel: { id: existing.id, model: existing.model, device_type_id: existing.device_type_id, brand: brandName, device_type: deviceTypeName },
+			deviceModel: {
+				id: existing.id,
+				model: existing.model,
+				device_type_id: existing.device_type_id,
+				organization_id: existing.organization_id,
+				brand: brandName,
+				device_type: deviceTypeName,
+			},
 			existed: true,
 		})
 	}
@@ -272,13 +337,13 @@ export async function POST(request: Request) {
 			model,
 			organization_id: auth.organizationId,
 		})
-		.select('id, model, device_type_id')
+		.select('id, model, device_type_id, organization_id')
 		.single()
 
 	if (error) {
 		const { data: after } = await auth.supabase
 			.from('device_models')
-			.select('id, model, device_type_id')
+			.select('id, model, device_type_id, organization_id')
 			.eq('organization_id', auth.organizationId)
 			.eq('device_type_id', deviceTypeId)
 			.eq('model', model)
@@ -286,7 +351,14 @@ export async function POST(request: Request) {
 		if (after?.id) {
 			return NextResponse.json({
 				ok: true,
-				deviceModel: { id: after.id, model: after.model, device_type_id: after.device_type_id, brand: brandName, device_type: deviceTypeName },
+				deviceModel: {
+					id: after.id,
+					model: after.model,
+					device_type_id: after.device_type_id,
+					organization_id: after.organization_id,
+					brand: brandName,
+					device_type: deviceTypeName,
+				},
 				existed: true,
 			})
 		}
@@ -295,8 +367,14 @@ export async function POST(request: Request) {
 
 	return NextResponse.json({
 		ok: true,
-		deviceModel: { id: inserted.id, model: inserted.model, device_type_id: inserted.device_type_id, brand: brandName, device_type: deviceTypeName },
+		deviceModel: {
+			id: inserted.id,
+			model: inserted.model,
+			device_type_id: inserted.device_type_id,
+			organization_id: inserted.organization_id,
+			brand: brandName,
+			device_type: deviceTypeName,
+		},
 		existed: false,
 	})
 }
-

--- a/src/app/api/portal/device-types/[id]/route.ts
+++ b/src/app/api/portal/device-types/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { requireStaffOrAdmin } from '@/lib/auth/portal-api'
+import { deviceCatalogOrganizationIds } from '@/lib/organizations/device-catalog'
 import { parseOptionalUuid } from '@/lib/utils/optional-uuid'
 
 function cleanText (value: string) {
@@ -29,7 +30,7 @@ export async function PATCH (
 		.from('device_brands')
 		.select('id')
 		.eq('id', brandId)
-		.eq('organization_id', auth.organizationId)
+		.in('organization_id', deviceCatalogOrganizationIds(auth.organizationId))
 		.maybeSingle()
 	if (!brandRow) {
 		return NextResponse.json({ ok: false, error: 'invalid_brand' }, { status: 400 })
@@ -39,7 +40,7 @@ export async function PATCH (
 		.update({ brand_id: brandId, name })
 		.eq('id', id)
 		.eq('organization_id', auth.organizationId)
-		.select('id, brand_id, name')
+		.select('id, brand_id, name, organization_id')
 		.maybeSingle()
 	if (error) {
 		if (error.code === '23505') {

--- a/src/app/api/portal/device-types/route.ts
+++ b/src/app/api/portal/device-types/route.ts
@@ -1,51 +1,74 @@
 import { NextResponse } from 'next/server'
 import { requireStaffOrAdmin } from '@/lib/auth/portal-api'
+import { CONECTIZE_HOST_ORGANIZATION_ID } from '@/lib/organizations/constants'
+import {
+  deviceCatalogOrganizationIds,
+  preferHostCatalogRows,
+} from '@/lib/organizations/device-catalog'
 
-function cleanText(value: string) {
+function cleanText (value: string) {
   return String(value || '').trim()
 }
 
-export async function GET(request: Request) {
+type TypeDbRow = {
+  id: string
+  brand_id?: string | null
+  name?: string | null
+  organization_id?: string | null
+  device_brands?: { name?: string | null } | { name?: string | null }[] | null
+}
+
+export async function GET (request: Request) {
   const auth = await requireStaffOrAdmin()
   if (auth.ok === false) {
     return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
   }
   const url = new URL(request.url)
   const brandId = cleanText(String(url.searchParams.get('brandId') || ''))
-  const query = auth.supabase
+  const orgIds = deviceCatalogOrganizationIds(auth.organizationId)
+
+  let query = auth.supabase
     .from('device_types')
-    .select('id, brand_id, name, device_brands ( id, name )')
-    .eq('organization_id', auth.organizationId)
+    .select('id, brand_id, name, organization_id, device_brands ( id, name )')
+    .in('organization_id', orgIds)
     .order('name', { ascending: true })
+
   if (brandId) {
-    query.eq('brand_id', brandId)
+    query = query.eq('brand_id', brandId)
   }
+
   const { data, error } = await query
   if (error) {
     console.error('[device-types GET]', error)
     const message = process.env.NODE_ENV === 'development' ? error.message : 'db_error'
     return NextResponse.json({ ok: false, error: 'db_error', message }, { status: 500 })
   }
-  type Row = {
-    id: string
-    brand_id?: string | null
-    name?: string | null
-    device_brands?: { name?: string | null } | { name?: string | null }[] | null
-  }
-  const rows = (data || []).map((row: Row) => {
+
+  const mapped = ((data || []) as TypeDbRow[]).map((row) => {
     const b = row.device_brands
     const brandName = Array.isArray(b) ? b[0]?.name : b?.name
     return {
       id: row.id,
       brand_id: row.brand_id,
       name: row.name,
+      organization_id: row.organization_id,
       brand_name: brandName ?? null,
     }
   })
-  return NextResponse.json({ ok: true, deviceTypes: rows })
+
+  const deviceTypes = preferHostCatalogRows(
+    mapped,
+    (row) => `${row.brand_id || ''}::${row.name || ''}`,
+  ).sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''), 'pt-BR', { sensitivity: 'base' }))
+
+  return NextResponse.json({
+    ok: true,
+    deviceTypes,
+    currentOrganizationId: auth.organizationId,
+  })
 }
 
-export async function POST(request: Request) {
+export async function POST (request: Request) {
   const auth = await requireStaffOrAdmin()
   if (auth.ok === false) {
     return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
@@ -56,25 +79,54 @@ export async function POST(request: Request) {
   if (!brandId || !name) {
     return NextResponse.json({ ok: false, error: 'invalid_payload' }, { status: 400 })
   }
+
+  const orgIds = deviceCatalogOrganizationIds(auth.organizationId)
   const { data: brandRow } = await auth.supabase
     .from('device_brands')
     .select('id')
     .eq('id', brandId)
-    .eq('organization_id', auth.organizationId)
+    .in('organization_id', orgIds)
     .maybeSingle()
   if (!brandRow) {
     return NextResponse.json({ ok: false, error: 'invalid_brand' }, { status: 400 })
   }
+
+  // Reutiliza tipo do host sob a mesma marca
+  if (auth.organizationId !== CONECTIZE_HOST_ORGANIZATION_ID) {
+    const { data: hostExisting } = await auth.supabase
+      .from('device_types')
+      .select('id, brand_id, name, organization_id')
+      .eq('organization_id', CONECTIZE_HOST_ORGANIZATION_ID)
+      .eq('brand_id', brandId)
+      .eq('name', name)
+      .maybeSingle()
+    if (hostExisting?.id) {
+      return NextResponse.json({ ok: true, deviceType: hostExisting, existed: true })
+    }
+  }
+
+  const { data: orgExisting } = await auth.supabase
+    .from('device_types')
+    .select('id, brand_id, name, organization_id')
+    .eq('organization_id', auth.organizationId)
+    .eq('brand_id', brandId)
+    .eq('name', name)
+    .maybeSingle()
+  if (orgExisting?.id) {
+    return NextResponse.json({ ok: true, deviceType: orgExisting, existed: true })
+  }
+
   const { data: inserted, error } = await auth.supabase
     .from('device_types')
     .insert({ brand_id: brandId, name, organization_id: auth.organizationId })
-    .select('id, brand_id, name')
+    .select('id, brand_id, name, organization_id')
     .single()
+
   if (error) {
     if (error.code === '23505') {
       const { data: existing } = await auth.supabase
         .from('device_types')
-        .select('id, brand_id, name')
+        .select('id, brand_id, name, organization_id')
         .eq('organization_id', auth.organizationId)
         .eq('brand_id', brandId)
         .eq('name', name)

--- a/src/app/api/portal/ordens/[id]/assistance-photos/[photoId]/route.ts
+++ b/src/app/api/portal/ordens/[id]/assistance-photos/[photoId]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireStaffOrAdmin } from '@/lib/auth/portal-api'
+import { parseOptionalUuid } from '@/lib/utils/optional-uuid'
+
+const BUCKET = 'order-assistance-photos'
+
+export async function DELETE (
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; photoId: string }> },
+) {
+  const auth = await requireStaffOrAdmin()
+  if (auth.ok === false) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  const { id: rawOrderId, photoId: rawPhotoId } = await params
+  const orderId = parseOptionalUuid(rawOrderId)
+  const photoId = parseOptionalUuid(rawPhotoId)
+  if (!orderId || !photoId) {
+    return NextResponse.json({ ok: false, error: 'invalid_id' }, { status: 400 })
+  }
+
+  const { data: row, error: findErr } = await auth.supabase
+    .from('service_order_assistance_photos')
+    .select('id, storage_path')
+    .eq('id', photoId)
+    .eq('service_order_id', orderId)
+    .maybeSingle()
+
+  if (findErr || !row) {
+    return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+  }
+
+  const storagePath = String(row.storage_path || '')
+  if (storagePath) {
+    await auth.supabase.storage.from(BUCKET).remove([storagePath])
+  }
+
+  const { error: delErr } = await auth.supabase
+    .from('service_order_assistance_photos')
+    .delete()
+    .eq('id', photoId)
+    .eq('service_order_id', orderId)
+
+  if (delErr) {
+    console.error('[assistance-photos DELETE]', delErr)
+    return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/portal/ordens/[id]/assistance-photos/route.ts
+++ b/src/app/api/portal/ordens/[id]/assistance-photos/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { randomUUID } from 'crypto'
+import { requireStaffOrAdmin } from '@/lib/auth/portal-api'
+import { parseOptionalUuid } from '@/lib/utils/optional-uuid'
+
+const BUCKET = 'order-assistance-photos'
+
+export async function GET (
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireStaffOrAdmin()
+  if (auth.ok === false) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  const { id: rawId } = await params
+  const orderId = parseOptionalUuid(rawId)
+  if (!orderId) {
+    return NextResponse.json({ ok: false, error: 'invalid_id' }, { status: 400 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const countOnly = searchParams.get('countOnly') === '1' || searchParams.get('countOnly') === 'true'
+
+  if (countOnly) {
+    const { count, error } = await auth.supabase
+      .from('service_order_assistance_photos')
+      .select('*', { count: 'exact', head: true })
+      .eq('service_order_id', orderId)
+
+    if (error) {
+      console.error('[assistance-photos count]', error)
+      return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })
+    }
+    return NextResponse.json({ ok: true, count: count ?? 0 })
+  }
+
+  const { data: rows, error } = await auth.supabase
+    .from('service_order_assistance_photos')
+    .select('id, storage_path, created_at')
+    .eq('service_order_id', orderId)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    console.error('[assistance-photos GET]', error)
+    return NextResponse.json({ ok: false, error: 'db_error' }, { status: 500 })
+  }
+
+  const expiresIn = 60 * 60
+  const photos = await Promise.all(
+    (rows ?? []).map(async (row: { id: string; storage_path: string; created_at: string }) => {
+      const { data: signed } = await auth.supabase.storage
+        .from(BUCKET)
+        .createSignedUrl(row.storage_path, expiresIn)
+      return {
+        id: row.id,
+        url: signed?.signedUrl ?? null,
+        created_at: row.created_at,
+      }
+    }),
+  )
+
+  return NextResponse.json({ ok: true, photos })
+}
+
+export async function POST (
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireStaffOrAdmin()
+  if (auth.ok === false) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  const { id: rawId } = await params
+  const orderId = parseOptionalUuid(rawId)
+  if (!orderId) {
+    return NextResponse.json({ ok: false, error: 'invalid_id' }, { status: 400 })
+  }
+
+  const formData = await request.formData()
+  const files = formData.getAll('files')
+  const uploaded: Array<{ id: string }> = []
+
+  for (const file of files) {
+    if (!(file instanceof Blob) || file.size === 0) continue
+    const mime = (file as File).type || 'image/jpeg'
+    const ext =
+      mime.includes('png') ? 'png'
+        : mime.includes('webp') ? 'webp'
+          : mime.includes('heic') ? 'heic'
+            : 'jpg'
+    const path = `${orderId}/${randomUUID()}.${ext}`
+    const buf = Buffer.from(await file.arrayBuffer())
+
+    const { error: upErr } = await auth.supabase.storage
+      .from(BUCKET)
+      .upload(path, buf, { contentType: mime, upsert: false })
+
+    if (upErr) {
+      console.error('[assistance-photos upload]', upErr)
+      continue
+    }
+
+    const { data: ins, error: insErr } = await auth.supabase
+      .from('service_order_assistance_photos')
+      .insert({
+        service_order_id: orderId,
+        storage_path: path,
+        organization_id: auth.organizationId,
+      })
+      .select('id')
+      .single()
+
+    if (!insErr && ins?.id) {
+      uploaded.push({ id: ins.id })
+    }
+  }
+
+  return NextResponse.json({ ok: true, photos: uploaded })
+}

--- a/src/app/os/[token]/OsPublicEntryPhotos.tsx
+++ b/src/app/os/[token]/OsPublicEntryPhotos.tsx
@@ -19,9 +19,14 @@ export type OsPublicPhotoItem = {
 type OsPublicEntryPhotosProps = {
   photos: OsPublicPhotoItem[]
   className?: string
+  title?: string
 }
 
-export function OsPublicEntryPhotos ({ photos, className }: OsPublicEntryPhotosProps) {
+export function OsPublicEntryPhotos ({
+  photos,
+  className,
+  title = 'Fotos do aparelho no momento da entrada',
+}: OsPublicEntryPhotosProps) {
   const [modalOpen, setModalOpen] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(0)
 
@@ -57,7 +62,7 @@ export function OsPublicEntryPhotos ({ photos, className }: OsPublicEntryPhotosP
   return (
     <>
       <div className={cn('space-y-3', className)}>
-        <h3 className="text-sm font-medium">Fotos do aparelho no momento da entrada</h3>
+        <h3 className="text-sm font-medium">{title}</h3>
         <ul className="grid grid-cols-6 sm:grid-cols-8 gap-1.5">
           {photos.map((photo, index) => (
             <li key={photo.id} className="list-none">

--- a/src/app/os/[token]/page.tsx
+++ b/src/app/os/[token]/page.tsx
@@ -193,25 +193,49 @@ export default async function OrdemPublicaPage({
 		: orderDeviceModels
 
 	let entryPhotos: Array<{ id: string; url: string | null; created_at: string }> = []
+	let exitPhotos: Array<{ id: string; url: string | null; created_at: string }> = []
+	let assistancePhotos: Array<{ id: string; url: string | null; created_at: string }> = []
 	if (order?.id) {
-		const { data: photoRows } = await supabase
-			.from('service_order_entry_photos')
-			.select('id, storage_path, created_at')
-			.eq('service_order_id', order.id)
-			.order('created_at', { ascending: true })
 		const expiresIn = 60 * 60
-		entryPhotos = await Promise.all(
-			(photoRows || []).map(async (row: { id: string; storage_path: string; created_at: string }) => {
+		const [entryRowsRes, exitRowsRes, assistanceRowsRes] = await Promise.all([
+			supabase
+				.from('service_order_entry_photos')
+				.select('id, storage_path, created_at')
+				.eq('service_order_id', order.id)
+				.order('created_at', { ascending: true }),
+			supabase
+				.from('service_order_exit_photos')
+				.select('id, storage_path, created_at')
+				.eq('service_order_id', order.id)
+				.order('created_at', { ascending: true }),
+			supabase
+				.from('service_order_assistance_photos')
+				.select('id, storage_path, created_at')
+				.eq('service_order_id', order.id)
+				.order('created_at', { ascending: true }),
+		])
+
+		const signRows = async (
+			photoRows: Array<{ id: string; storage_path: string; created_at: string }> | null,
+			bucket: string,
+		) => Promise.all(
+			(photoRows || []).map(async (row) => {
 				const { data: signed } = await supabase.storage
-					.from('order-entry-photos')
+					.from(bucket)
 					.createSignedUrl(row.storage_path, expiresIn)
 				return {
 					id: row.id,
 					url: signed?.signedUrl ?? null,
 					created_at: row.created_at,
 				}
-			})
+			}),
 		)
+
+		;[entryPhotos, exitPhotos, assistancePhotos] = await Promise.all([
+			signRows(entryRowsRes.data, 'order-entry-photos'),
+			signRows(exitRowsRes.data, 'order-exit-photos'),
+			signRows(assistanceRowsRes.data, 'order-assistance-photos'),
+		])
 	}
 
 	if (!order) {
@@ -292,6 +316,8 @@ export default async function OrdemPublicaPage({
 		notTestedExit ||
 		Object.keys(exitChecksData.checks).length > 0
 	const hasEntryPhotos = entryPhotos.length > 0
+	const hasExitPhotos = exitPhotos.length > 0
+	const hasAssistancePhotos = assistancePhotos.length > 0
 
 	const cadastroHref = isHostOrg
 		? '/portal/cadastro'
@@ -375,9 +401,16 @@ export default async function OrdemPublicaPage({
 
 								{hasExitChecks && (
 									<OsPublicDeviceChecksSection
-										title="Itens testados no momento da saída"
+										title="Situação de saída do aparelho"
 										momentShort="saída"
 										parsed={exitChecksData}
+									/>
+								)}
+
+								{hasExitPhotos && (
+									<OsPublicEntryPhotos
+										photos={exitPhotos}
+										title="Fotos do aparelho no momento de saída"
 									/>
 								)}
 
@@ -403,6 +436,13 @@ export default async function OrdemPublicaPage({
 											{assistanceInfoText}
 										</p>
 									</div>
+								)}
+
+								{hasAssistancePhotos && (
+									<OsPublicEntryPhotos
+										photos={assistancePhotos}
+										title="Fotos da assistência"
+									/>
 								)}
 
 								{hasPaymentMethods && (

--- a/src/components/orders/OrderDeviceSelector.tsx
+++ b/src/components/orders/OrderDeviceSelector.tsx
@@ -15,7 +15,7 @@ export type DeviceModel = {
   model: string
 }
 
-const DEVICE_MODELS_CACHE_KEY = 'portal_device_models_v1'
+const DEVICE_MODELS_CACHE_KEY = 'portal_device_models_v2'
 const DEVICE_MODELS_CACHE_TTL_MS = 5 * 60 * 1000 // 5 min
 
 function getCachedDeviceModels(): DeviceModel[] | null {

--- a/src/lib/admin/storage-usage.ts
+++ b/src/lib/admin/storage-usage.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { listServiceOrderPhotosWithSizes } from '@/lib/orders/service-order-photos-admin'
 import {
+  SERVICE_ORDER_ASSISTANCE_PHOTOS_BUCKET,
   SERVICE_ORDER_ENTRY_PHOTOS_BUCKET,
   SERVICE_ORDER_EXIT_PHOTOS_BUCKET,
 } from '@/lib/orders/service-order-photos-cleanup'
@@ -16,7 +17,7 @@ export type StorageUsageBucket = {
   bytes: number
 }
 
-export type StorageUsageCategoryKey = 'os_entry' | 'os_exit' | 'whatsapp' | 'resale'
+export type StorageUsageCategoryKey = 'os_entry' | 'os_exit' | 'os_assistance' | 'whatsapp' | 'resale'
 
 export type StorageUsageCategory = {
   key: StorageUsageCategoryKey
@@ -83,7 +84,7 @@ function toCategory (value: unknown): StorageUsageCategory | null {
   if (!value || typeof value !== 'object') return null
   const row = value as Record<string, unknown>
   const key = String(row.key || '').trim() as StorageUsageCategoryKey
-  if (!['os_entry', 'os_exit', 'whatsapp', 'resale'].includes(key)) return null
+  if (!['os_entry', 'os_exit', 'os_assistance', 'whatsapp', 'resale'].includes(key)) return null
   return {
     key,
     label: String(row.label || key),
@@ -243,20 +244,24 @@ async function getFallbackStorageUsageSummary (
 
   const entryPhotos = serviceOrderPhotos.filter((photo) => photo.kind === 'entry')
   const exitPhotos = serviceOrderPhotos.filter((photo) => photo.kind === 'exit')
+  const assistancePhotos = serviceOrderPhotos.filter((photo) => photo.kind === 'assistance')
   const entryBytes = entryPhotos.reduce((sum, photo) => sum + (photo.sizeBytes ?? 0), 0)
   const exitBytes = exitPhotos.reduce((sum, photo) => sum + (photo.sizeBytes ?? 0), 0)
+  const assistanceBytes = assistancePhotos.reduce((sum, photo) => sum + (photo.sizeBytes ?? 0), 0)
   const whatsappBytes = whatsappImages.reduce((sum, image) => sum + (image.sizeBytes ?? 0), 0)
   const resaleBytes = resalePhotos.reduce((sum, photo) => sum + (photo.sizeBytes ?? 0), 0)
 
   const categories = [
     buildCategory('os_entry', 'Fotos de entrada de OS', entryPhotos.length, entryBytes),
     buildCategory('os_exit', 'Fotos de saída de OS', exitPhotos.length, exitBytes),
+    buildCategory('os_assistance', 'Fotos da assistência de OS', assistancePhotos.length, assistanceBytes),
     buildCategory('whatsapp', 'Imagens do WhatsApp', whatsappImages.length, whatsappBytes),
     buildCategory('resale', 'Fotos de seminovos', resalePhotos.length, resaleBytes),
   ]
   const buckets = [
     buildBucket(SERVICE_ORDER_ENTRY_PHOTOS_BUCKET, entryPhotos.length, entryBytes),
     buildBucket(SERVICE_ORDER_EXIT_PHOTOS_BUCKET, exitPhotos.length, exitBytes),
+    buildBucket(SERVICE_ORDER_ASSISTANCE_PHOTOS_BUCKET, assistancePhotos.length, assistanceBytes),
     buildBucket(WHATSAPP_MEDIA_BUCKET, whatsappImages.length, whatsappBytes),
     buildBucket(RESALE_DEVICE_PHOTOS_BUCKET, resalePhotos.length, resaleBytes),
   ].sort((a, b) => b.bytes - a.bytes)

--- a/src/lib/finance/staff-commissions.ts
+++ b/src/lib/finance/staff-commissions.ts
@@ -1,0 +1,341 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { resolveOrderCommissionCents } from '@/lib/orders/order-discount-commission'
+import { getOrdemPortalPath } from '@/lib/orders/ordem-portal-path'
+import {
+  isCommissionCostDescription,
+  parseCommissionWorkerLabelFromDescription,
+} from '@/lib/resale/resale-sale-costs'
+
+export type StaffCommissionSource = 'os' | 'resale'
+
+export type StaffCommissionItem = {
+  id: string
+  source: StaffCommissionSource
+  sourceId: string
+  href: string
+  label: string
+  userId: string | null
+  userDisplayName: string
+  amountCents: number
+  earnedAt: string
+  paidAt: string | null
+  isPaid: boolean
+}
+
+export type StaffCommissionListFilters = {
+  organizationId: string
+  from: string
+  to: string
+  status?: 'all' | 'pending' | 'paid'
+  source?: 'all' | StaffCommissionSource
+}
+
+type OrderRow = {
+  id: string
+  display_number: number | string | null
+  title: string | null
+  status: string
+  closed_at: string | null
+  updated_at: string | null
+  services_total_cents: number | null
+  discount_cents: number | null
+  commission_user_id: string | null
+  commission_kind: string | null
+  commission_fixed_cents: number | null
+  commission_percent: number | null
+  commission_paid_at: string | null
+}
+
+type ResaleRow = {
+  id: string
+  sale_date: string | null
+  sold_for_cents: number | null
+  device_name: string | null
+  model: string | null
+  device_model_id: string | null
+  sale_commission_user_id: string | null
+  commission_paid_at: string | null
+}
+
+const OS_COMMISSION_STATUSES = [
+  'finalizada',
+  'finalizada_sem_conserto',
+  'finalizada_sem_aprovacao',
+] as const
+
+function ymd (isoOrDate: string | null | undefined): string {
+  return String(isoOrDate || '').slice(0, 10)
+}
+
+function userLabel (
+  usersMap: Map<string, string>,
+  userId: string | null,
+  fallback?: string | null,
+): string {
+  if (userId && usersMap.has(userId)) return usersMap.get(userId) || 'Colaborador'
+  const fb = String(fallback || '').trim()
+  return fb || 'Colaborador'
+}
+
+async function loadUserNames (
+  supabase: SupabaseClient,
+  userIds: string[],
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>()
+  const unique = [...new Set(userIds.map((id) => id.trim()).filter(Boolean))]
+  if (unique.length === 0) return map
+
+  const chunkSize = 100
+  for (let i = 0; i < unique.length; i += chunkSize) {
+    const slice = unique.slice(i, i + chunkSize)
+    const { data } = await supabase
+      .from('users')
+      .select('id, full_name, email')
+      .in('id', slice)
+    for (const row of data || []) {
+      const name =
+        String(row.full_name || '').trim() ||
+        String(row.email || '').trim() ||
+        'Colaborador'
+      map.set(row.id, name)
+    }
+  }
+  return map
+}
+
+async function listOsCommissions (
+  supabase: SupabaseClient,
+  organizationId: string,
+  from: string,
+  to: string,
+): Promise<StaffCommissionItem[]> {
+  const { data, error } = await supabase
+    .from('service_orders')
+    .select(
+      'id, display_number, title, status, closed_at, updated_at, services_total_cents, discount_cents, commission_user_id, commission_kind, commission_fixed_cents, commission_percent, commission_paid_at',
+    )
+    .eq('organization_id', organizationId)
+    .not('commission_user_id', 'is', null)
+    .in('status', [...OS_COMMISSION_STATUSES])
+    .gte('closed_at', from)
+    .lte('closed_at', `${to}T23:59:59.999`)
+    .order('closed_at', { ascending: false })
+    .limit(2000)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const rows = (data || []) as OrderRow[]
+  const items: StaffCommissionItem[] = []
+
+  for (const row of rows) {
+    const earnedAt = ymd(row.closed_at) || ymd(row.updated_at)
+    if (!earnedAt || earnedAt < from || earnedAt > to) continue
+
+    const amountCents = resolveOrderCommissionCents(row)
+    if (amountCents <= 0) continue
+
+    const userId = String(row.commission_user_id || '').trim() || null
+    const display =
+      row.display_number != null && String(row.display_number).trim()
+        ? `OS #${row.display_number}`
+        : 'OS'
+    const title = String(row.title || '').trim()
+    items.push({
+      id: `os:${row.id}`,
+      source: 'os',
+      sourceId: row.id,
+      href: getOrdemPortalPath(row),
+      label: title ? `${display} — ${title}` : display,
+      userId,
+      userDisplayName: '',
+      amountCents,
+      earnedAt,
+      paidAt: row.commission_paid_at,
+      isPaid: Boolean(row.commission_paid_at),
+    })
+  }
+
+  return items
+}
+
+async function listResaleCommissions (
+  supabase: SupabaseClient,
+  organizationId: string,
+  from: string,
+  to: string,
+): Promise<StaffCommissionItem[]> {
+  const { data: soldDevices, error } = await supabase
+    .from('resale_devices')
+    .select(
+      'id, sale_date, sold_for_cents, device_name, model, device_model_id, sale_commission_user_id, commission_paid_at',
+    )
+    .eq('organization_id', organizationId)
+    .eq('sold', true)
+    .gte('sale_date', from)
+    .lte('sale_date', to)
+    .order('sale_date', { ascending: false })
+    .limit(2000)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const list = (soldDevices || []) as ResaleRow[]
+  if (list.length === 0) return []
+
+  const commissionByDevice = new Map<string, { cents: number; labelHint: string | null }>()
+  const idList = list.map((d) => d.id)
+  const chunkSize = 100
+  for (let i = 0; i < idList.length; i += chunkSize) {
+    const slice = idList.slice(i, i + chunkSize)
+    const { data: costRows, error: costsError } = await supabase
+      .from('resale_device_costs')
+      .select('resale_device_id, description, value_cents')
+      .in('resale_device_id', slice)
+
+    if (costsError) {
+      throw new Error(costsError.message)
+    }
+
+    for (const row of costRows || []) {
+      if (!isCommissionCostDescription(row.description)) continue
+      const v = Number(row.value_cents) || 0
+      if (v <= 0) continue
+      const id = String(row.resale_device_id)
+      const prev = commissionByDevice.get(id) ?? { cents: 0, labelHint: null }
+      prev.cents += v
+      if (!prev.labelHint) {
+        prev.labelHint = parseCommissionWorkerLabelFromDescription(row.description)
+      }
+      commissionByDevice.set(id, prev)
+    }
+  }
+
+  const modelIds = [
+    ...new Set(list.map((d) => d.device_model_id).filter(Boolean) as string[]),
+  ]
+  const modelsMap = new Map<string, string>()
+  for (let i = 0; i < modelIds.length; i += chunkSize) {
+    const slice = modelIds.slice(i, i + chunkSize)
+    const { data: models } = await supabase
+      .from('device_models')
+      .select('id, model, device_types ( name, device_brands ( name ) )')
+      .in('id', slice)
+    for (const m of models || []) {
+      const dtRaw = (m as { device_types?: unknown }).device_types
+      const dt = Array.isArray(dtRaw) ? dtRaw[0] : dtRaw
+      const brRaw = dt && (dt as { device_brands?: unknown }).device_brands
+      const br = Array.isArray(brRaw) ? brRaw[0] : brRaw
+      const brand = String((br as { name?: string } | null)?.name || '').trim()
+      const typeName = String((dt as { name?: string } | null)?.name || '').trim()
+      const model = String(m.model || '').trim()
+      modelsMap.set(
+        m.id,
+        [brand, typeName, model].filter(Boolean).join(' ') || model || 'Aparelho',
+      )
+    }
+  }
+
+  const items: StaffCommissionItem[] = []
+  for (const d of list) {
+    const info = commissionByDevice.get(d.id)
+    if (!info || info.cents <= 0) continue
+    const earnedAt = ymd(d.sale_date)
+    if (!earnedAt) continue
+
+    const modelLabel = d.device_model_id
+      ? modelsMap.get(d.device_model_id) || ''
+      : ''
+    const fallback =
+      String(d.device_name || '').trim() ||
+      String(d.model || '').trim() ||
+      modelLabel ||
+      'Aparelho vendido'
+
+    items.push({
+      id: `resale:${d.id}`,
+      source: 'resale',
+      sourceId: d.id,
+      href: `/portal/revendaaparelhos/${d.id}`,
+      label: fallback,
+      userId: String(d.sale_commission_user_id || '').trim() || null,
+      userDisplayName: info.labelHint || '',
+      amountCents: info.cents,
+      earnedAt,
+      paidAt: d.commission_paid_at,
+      isPaid: Boolean(d.commission_paid_at),
+    })
+  }
+
+  return items
+}
+
+export async function listStaffCommissions (
+  supabase: SupabaseClient,
+  filters: StaffCommissionListFilters,
+): Promise<StaffCommissionItem[]> {
+  const status = filters.status || 'all'
+  const source = filters.source || 'all'
+  const from = ymd(filters.from)
+  const to = ymd(filters.to)
+  if (!from || !to) return []
+
+  const parts: StaffCommissionItem[][] = []
+  if (source === 'all' || source === 'os') {
+    parts.push(await listOsCommissions(supabase, filters.organizationId, from, to))
+  }
+  if (source === 'all' || source === 'resale') {
+    parts.push(await listResaleCommissions(supabase, filters.organizationId, from, to))
+  }
+
+  let items = parts.flat()
+  if (status === 'pending') items = items.filter((i) => !i.isPaid)
+  if (status === 'paid') items = items.filter((i) => i.isPaid)
+
+  const usersMap = await loadUserNames(
+    supabase,
+    items.map((i) => i.userId || '').filter(Boolean),
+  )
+
+  for (const item of items) {
+    item.userDisplayName = userLabel(usersMap, item.userId, item.userDisplayName)
+  }
+
+  items.sort((a, b) => {
+    if (a.earnedAt !== b.earnedAt) return b.earnedAt.localeCompare(a.earnedAt)
+    if (a.isPaid !== b.isPaid) return a.isPaid ? 1 : -1
+    return b.amountCents - a.amountCents
+  })
+
+  return items
+}
+
+export async function setStaffCommissionPaid (
+  supabase: SupabaseClient,
+  organizationId: string,
+  source: StaffCommissionSource,
+  sourceId: string,
+  paid: boolean,
+): Promise<{ paidAt: string | null }> {
+  const paidAt = paid ? new Date().toISOString() : null
+  const table = source === 'os' ? 'service_orders' : 'resale_devices'
+
+  const { data, error } = await supabase
+    .from(table)
+    .update({ commission_paid_at: paidAt })
+    .eq('id', sourceId)
+    .eq('organization_id', organizationId)
+    .select('id, commission_paid_at')
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+  if (!data) {
+    throw new Error('not_found')
+  }
+
+  return { paidAt: data.commission_paid_at ?? null }
+}

--- a/src/lib/orders/order-discount-commission.ts
+++ b/src/lib/orders/order-discount-commission.ts
@@ -44,6 +44,34 @@ export function resolveOrderPayableCents (
   return Math.max(0, (Math.trunc(servicesTotalCents) || 0) - (Math.trunc(discountCents) || 0))
 }
 
+/** Valor da comissão da OS a partir da regra gravada (fixo ou % sobre o líquido). */
+export function resolveOrderCommissionCents (order: {
+  services_total_cents?: unknown
+  discount_cents?: unknown
+  commission_user_id?: unknown
+  commission_kind?: unknown
+  commission_fixed_cents?: unknown
+  commission_percent?: unknown
+} | null | undefined): number {
+  if (!order) return 0
+  const userId = String(order.commission_user_id || '').trim()
+  if (!userId) return 0
+
+  const kindRaw = String(order.commission_kind || 'percent').trim()
+  if (kindRaw === 'fixed') {
+    return Math.max(0, Math.trunc(Number(order.commission_fixed_cents) || 0))
+  }
+
+  const percent = parsePercent(order.commission_percent)
+  if (percent <= 0) return 0
+  const payable = resolveOrderPayableCents(
+    Number(order.services_total_cents) || 0,
+    Number(order.discount_cents) || 0,
+  )
+  if (payable <= 0) return 0
+  return Math.floor((payable * percent) / 100)
+}
+
 export type OrderDiscountCommissionDbPayload = {
   discount_cents: number
   discount_mode: OrderDiscountMode

--- a/src/lib/orders/service-order-photos-admin.ts
+++ b/src/lib/orders/service-order-photos-admin.ts
@@ -1,10 +1,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import {
+  SERVICE_ORDER_ASSISTANCE_PHOTOS_BUCKET,
   SERVICE_ORDER_ENTRY_PHOTOS_BUCKET,
   SERVICE_ORDER_EXIT_PHOTOS_BUCKET,
 } from '@/lib/orders/service-order-photos-cleanup'
 
-export type ServiceOrderPhotoKind = 'entry' | 'exit'
+export type ServiceOrderPhotoKind = 'entry' | 'exit' | 'assistance'
 
 export type ServiceOrderPhotoListItem = {
   id: string
@@ -25,8 +26,25 @@ type PhotoDbRow = {
   service_orders: { display_number: string | null } | { display_number: string | null }[] | null
 }
 
+type PhotoTable =
+  | 'service_order_entry_photos'
+  | 'service_order_exit_photos'
+  | 'service_order_assistance_photos'
+
 const FOLDER_LIST_CONCURRENCY = 8
 const SIGNED_URL_EXPIRES_SECONDS = 60 * 60
+
+const KIND_TABLE: Record<ServiceOrderPhotoKind, PhotoTable> = {
+  entry: 'service_order_entry_photos',
+  exit: 'service_order_exit_photos',
+  assistance: 'service_order_assistance_photos',
+}
+
+const KIND_BUCKET: Record<ServiceOrderPhotoKind, string> = {
+  entry: SERVICE_ORDER_ENTRY_PHOTOS_BUCKET,
+  exit: SERVICE_ORDER_EXIT_PHOTOS_BUCKET,
+  assistance: SERVICE_ORDER_ASSISTANCE_PHOTOS_BUCKET,
+}
 
 function resolveOrderNumber (
   serviceOrders: PhotoDbRow['service_orders'],
@@ -91,7 +109,7 @@ async function buildStorageSizeMap (
 async function fetchPhotoRows (
   supabase: SupabaseClient,
   organizationId: string,
-  table: 'service_order_entry_photos' | 'service_order_exit_photos',
+  table: PhotoTable,
 ): Promise<PhotoDbRow[]> {
   const { data, error } = await supabase
     .from(table)
@@ -138,25 +156,35 @@ export async function listServiceOrderPhotosWithSizes (
   supabase: SupabaseClient,
   organizationId: string,
 ): Promise<ServiceOrderPhotoListItem[]> {
-  const [entryRows, exitRows] = await Promise.all([
+  const [entryRows, exitRows, assistanceRows] = await Promise.all([
     fetchPhotoRows(supabase, organizationId, 'service_order_entry_photos'),
     fetchPhotoRows(supabase, organizationId, 'service_order_exit_photos'),
+    fetchPhotoRows(supabase, organizationId, 'service_order_assistance_photos'),
   ])
 
   const entryPaths = entryRows.map((row) => String(row.storage_path || '').trim()).filter(Boolean)
   const exitPaths = exitRows.map((row) => String(row.storage_path || '').trim()).filter(Boolean)
+  const assistancePaths = assistanceRows.map((row) => String(row.storage_path || '').trim()).filter(Boolean)
 
-  const [entrySizes, exitSizes] = await Promise.all([
+  const [entrySizes, exitSizes, assistanceSizes] = await Promise.all([
     buildStorageSizeMap(supabase, SERVICE_ORDER_ENTRY_PHOTOS_BUCKET, entryPaths),
     buildStorageSizeMap(supabase, SERVICE_ORDER_EXIT_PHOTOS_BUCKET, exitPaths),
+    buildStorageSizeMap(supabase, SERVICE_ORDER_ASSISTANCE_PHOTOS_BUCKET, assistancePaths),
   ])
 
-  const [entryItems, exitItems] = await Promise.all([
+  const [entryItems, exitItems, assistanceItems] = await Promise.all([
     mapRowsToListItems(supabase, entryRows, 'entry', SERVICE_ORDER_ENTRY_PHOTOS_BUCKET, entrySizes),
     mapRowsToListItems(supabase, exitRows, 'exit', SERVICE_ORDER_EXIT_PHOTOS_BUCKET, exitSizes),
+    mapRowsToListItems(
+      supabase,
+      assistanceRows,
+      'assistance',
+      SERVICE_ORDER_ASSISTANCE_PHOTOS_BUCKET,
+      assistanceSizes,
+    ),
   ])
 
-  return [...entryItems, ...exitItems].sort((a, b) => {
+  return [...entryItems, ...exitItems, ...assistanceItems].sort((a, b) => {
     const sizeA = a.sizeBytes ?? -1
     const sizeB = b.sizeBytes ?? -1
     if (sizeB !== sizeA) return sizeB - sizeA
@@ -170,8 +198,8 @@ export async function deleteServiceOrderPhoto (
   photoId: string,
   kind: ServiceOrderPhotoKind,
 ): Promise<void> {
-  const table = kind === 'entry' ? 'service_order_entry_photos' : 'service_order_exit_photos'
-  const bucket = kind === 'entry' ? SERVICE_ORDER_ENTRY_PHOTOS_BUCKET : SERVICE_ORDER_EXIT_PHOTOS_BUCKET
+  const table = KIND_TABLE[kind]
+  const bucket = KIND_BUCKET[kind]
 
   const { data: row, error: findErr } = await supabase
     .from(table)

--- a/src/lib/orders/service-order-photos-cleanup.ts
+++ b/src/lib/orders/service-order-photos-cleanup.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 
 export const SERVICE_ORDER_ENTRY_PHOTOS_BUCKET = 'order-entry-photos'
 export const SERVICE_ORDER_EXIT_PHOTOS_BUCKET = 'order-exit-photos'
+export const SERVICE_ORDER_ASSISTANCE_PHOTOS_BUCKET = 'order-assistance-photos'
 export const SERVICE_ORDER_PHOTO_RETENTION_MONTHS = 3
 
 const BATCH_SIZE = 100
@@ -12,9 +13,15 @@ type PhotoRow = {
   storage_path: string
 }
 
+type PhotoTable =
+  | 'service_order_entry_photos'
+  | 'service_order_exit_photos'
+  | 'service_order_assistance_photos'
+
 export type ServiceOrderPhotosCleanupPreview = {
   entryCount: number
   exitCount: number
+  assistanceCount: number
   totalCount: number
   cutoffAt: string
   retentionMonths: number
@@ -23,6 +30,7 @@ export type ServiceOrderPhotosCleanupPreview = {
 export type ServiceOrderPhotosCleanupResult = ServiceOrderPhotosCleanupPreview & {
   entryDeleted: number
   exitDeleted: number
+  assistanceDeleted: number
   storageRemoveErrors: number
 }
 
@@ -39,7 +47,7 @@ export function getServiceOrderPhotoCutoffIso (): string {
 async function countOldPhotos (
   supabase: SupabaseClient,
   organizationId: string,
-  table: 'service_order_entry_photos' | 'service_order_exit_photos',
+  table: PhotoTable,
   cutoffIso: string,
 ): Promise<number> {
   const { count, error } = await supabase
@@ -60,15 +68,17 @@ export async function previewOldServiceOrderPhotosCleanup (
   organizationId: string,
 ): Promise<ServiceOrderPhotosCleanupPreview> {
   const cutoffAt = getServiceOrderPhotoCutoffIso()
-  const [entryCount, exitCount] = await Promise.all([
+  const [entryCount, exitCount, assistanceCount] = await Promise.all([
     countOldPhotos(supabase, organizationId, 'service_order_entry_photos', cutoffAt),
     countOldPhotos(supabase, organizationId, 'service_order_exit_photos', cutoffAt),
+    countOldPhotos(supabase, organizationId, 'service_order_assistance_photos', cutoffAt),
   ])
 
   return {
     entryCount,
     exitCount,
-    totalCount: entryCount + exitCount,
+    assistanceCount,
+    totalCount: entryCount + exitCount + assistanceCount,
     cutoffAt,
     retentionMonths: SERVICE_ORDER_PHOTO_RETENTION_MONTHS,
   }
@@ -78,7 +88,7 @@ async function cleanupPhotoTable (
   supabase: SupabaseClient,
   organizationId: string,
   cutoffIso: string,
-  table: 'service_order_entry_photos' | 'service_order_exit_photos',
+  table: PhotoTable,
   bucket: string,
 ): Promise<{ deleted: number; storageRemoveErrors: number }> {
   let deleted = 0
@@ -137,7 +147,7 @@ export async function runOldServiceOrderPhotosCleanup (
   const preview = await previewOldServiceOrderPhotosCleanup(supabase, organizationId)
   const cutoffIso = preview.cutoffAt
 
-  const [entryResult, exitResult] = await Promise.all([
+  const [entryResult, exitResult, assistanceResult] = await Promise.all([
     cleanupPhotoTable(
       supabase,
       organizationId,
@@ -152,12 +162,23 @@ export async function runOldServiceOrderPhotosCleanup (
       'service_order_exit_photos',
       SERVICE_ORDER_EXIT_PHOTOS_BUCKET,
     ),
+    cleanupPhotoTable(
+      supabase,
+      organizationId,
+      cutoffIso,
+      'service_order_assistance_photos',
+      SERVICE_ORDER_ASSISTANCE_PHOTOS_BUCKET,
+    ),
   ])
 
   return {
     ...preview,
     entryDeleted: entryResult.deleted,
     exitDeleted: exitResult.deleted,
-    storageRemoveErrors: entryResult.storageRemoveErrors + exitResult.storageRemoveErrors,
+    assistanceDeleted: assistanceResult.deleted,
+    storageRemoveErrors:
+      entryResult.storageRemoveErrors +
+      exitResult.storageRemoveErrors +
+      assistanceResult.storageRemoveErrors,
   }
 }

--- a/src/lib/organizations/device-catalog.ts
+++ b/src/lib/organizations/device-catalog.ts
@@ -1,0 +1,44 @@
+import { CONECTIZE_HOST_ORGANIZATION_ID } from '@/lib/organizations/constants'
+
+/** Orgs visíveis no catálogo: host (Conectize) + organização atual. */
+export function deviceCatalogOrganizationIds (organizationId: string): string[] {
+  const current = String(organizationId || '').trim()
+  if (!current) return [CONECTIZE_HOST_ORGANIZATION_ID]
+  if (current === CONECTIZE_HOST_ORGANIZATION_ID) return [current]
+  return [CONECTIZE_HOST_ORGANIZATION_ID, current]
+}
+
+export function isHostCatalogOrganization (organizationId: string | null | undefined): boolean {
+  return String(organizationId || '').trim() === CONECTIZE_HOST_ORGANIZATION_ID
+}
+
+/**
+ * Prefere itens do host quando há o mesmo nome (case-insensitive).
+ * Host primeiro na ordenação para ganhar o Map.
+ */
+export function preferHostCatalogRows <T extends { organization_id?: string | null }> (
+  rows: T[],
+  keyFn: (row: T) => string,
+): T[] {
+  const sorted = [...rows].sort((a, b) => {
+    const aHost = isHostCatalogOrganization(a.organization_id) ? 0 : 1
+    const bHost = isHostCatalogOrganization(b.organization_id) ? 0 : 1
+    return aHost - bHost
+  })
+  const byKey = new Map<string, T>()
+  for (const row of sorted) {
+    const key = keyFn(row).trim().toLowerCase()
+    if (!key || byKey.has(key)) continue
+    byKey.set(key, row)
+  }
+  return [...byKey.values()]
+}
+
+export function canManageDeviceCatalogItem (
+  itemOrganizationId: string | null | undefined,
+  currentOrganizationId: string | null | undefined,
+): boolean {
+  const item = String(itemOrganizationId || '').trim()
+  const current = String(currentOrganizationId || '').trim()
+  return Boolean(item && current && item === current)
+}

--- a/src/lib/portal/device-models-server.ts
+++ b/src/lib/portal/device-models-server.ts
@@ -1,4 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  deviceCatalogOrganizationIds,
+  preferHostCatalogRows,
+} from '@/lib/organizations/device-catalog'
+import { getPortalOrganizationId } from '@/lib/organizations/portal-organization-context'
 
 export type DeviceModelForSelector = {
   id: string
@@ -11,17 +16,34 @@ const DEFAULT_LIMIT = 1000
 
 /**
  * Busca device models no servidor (para uso em Server Components).
+ * Inclui catálogo da Conectize (host) + catálogo da organização atual.
  * Retorna no formato esperado pelo OrderDeviceSelector.
  */
-export async function fetchDeviceModelsForSelector(
+export async function fetchDeviceModelsForSelector (
   supabase: SupabaseClient,
-  limit = DEFAULT_LIMIT
+  limit = DEFAULT_LIMIT,
+  organizationId?: string | null,
 ): Promise<DeviceModelForSelector[]> {
-  const { data, error } = await supabase
+  let orgId = String(organizationId || '').trim()
+  if (!orgId) {
+    const { data: authData } = await supabase.auth.getUser()
+    const userId = authData?.user?.id
+    if (userId) {
+      orgId = (await getPortalOrganizationId(supabase, userId)) || ''
+    }
+  }
+
+  let query = supabase
     .from('device_models')
-    .select('id, model, device_type_id, device_types ( id, name, device_brands ( id, name ) )')
+    .select('id, model, device_type_id, organization_id, device_types ( id, name, device_brands ( id, name ) )')
     .order('model', { ascending: true })
-    .limit(Math.min(Math.max(1, limit), 2000))
+    .limit(Math.min(Math.max(1, limit) * 2, 4000))
+
+  if (orgId) {
+    query = query.in('organization_id', deviceCatalogOrganizationIds(orgId))
+  }
+
+  const { data, error } = await query
 
   if (error) return []
 
@@ -30,10 +52,12 @@ export async function fetchDeviceModelsForSelector(
   type DeviceModelRow = {
     id: string
     model?: string | null
+    device_type_id?: string | null
+    organization_id?: string | null
     device_types?: DeviceTypeRow | DeviceTypeRow[] | null
   }
 
-  const rows = (data || []).map((row: DeviceModelRow) => {
+  const mapped = (data || []).map((row: DeviceModelRow) => {
     const dt = Array.isArray(row.device_types) ? row.device_types[0] : row.device_types
     const brandRow = dt && (Array.isArray(dt.device_brands) ? dt.device_brands[0] : dt.device_brands)
     return {
@@ -41,8 +65,17 @@ export async function fetchDeviceModelsForSelector(
       model: row.model ?? '',
       brand: brandRow?.name ?? '',
       device_type: dt?.name ?? '',
+      organization_id: row.organization_id ?? null,
+      device_type_id: row.device_type_id ?? null,
     }
   })
 
-  return rows
+  const deduped = preferHostCatalogRows(
+    mapped,
+    (row) => `${row.brand}::${row.device_type}::${row.model}`,
+  )
+    .sort((a, b) => a.model.localeCompare(b.model, 'pt-BR', { sensitivity: 'base' }))
+    .slice(0, Math.min(Math.max(1, limit), 2000))
+
+  return deduped.map(({ id, brand, device_type, model }) => ({ id, brand, device_type, model }))
 }

--- a/supabase/migrations/20260814120000_add_service_order_assistance_photos.sql
+++ b/supabase/migrations/20260814120000_add_service_order_assistance_photos.sql
@@ -1,0 +1,216 @@
+-- Fotos da assistência (visíveis ao cliente no link público da OS)
+
+create table if not exists public.service_order_assistance_photos (
+  id uuid primary key default gen_random_uuid(),
+  service_order_id uuid not null references public.service_orders(id) on delete cascade,
+  storage_path text not null,
+  created_at timestamptz not null default now(),
+  organization_id uuid not null references public.organizations(id)
+);
+
+create index if not exists service_order_assistance_photos_order_id_idx
+  on public.service_order_assistance_photos(service_order_id);
+
+create index if not exists service_order_assistance_photos_org_id_idx
+  on public.service_order_assistance_photos(organization_id);
+
+alter table public.service_order_assistance_photos enable row level security;
+
+drop policy if exists service_order_assistance_photos_staff_admin_all on public.service_order_assistance_photos;
+create policy service_order_assistance_photos_staff_admin_all
+  on public.service_order_assistance_photos for all
+  to authenticated
+  using (
+    public.is_staff_or_admin()
+    and service_order_assistance_photos.organization_id = public.current_organization_id()
+  )
+  with check (
+    public.is_staff_or_admin()
+    and service_order_assistance_photos.organization_id = public.current_organization_id()
+  );
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'order-assistance-photos',
+  'order-assistance-photos',
+  false,
+  10485760,
+  array['image/jpeg', 'image/png', 'image/webp', 'image/heic']
+)
+on conflict (id) do update set
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+drop policy if exists order_assistance_photos_staff_admin_all on storage.objects;
+create policy order_assistance_photos_staff_admin_all
+  on storage.objects for all
+  to authenticated
+  using (
+    bucket_id = 'order-assistance-photos'
+    and public.is_staff_or_admin()
+    and exists (
+      select 1
+      from public.service_orders s
+      where s.id::text = split_part(name, '/', 1)
+        and s.organization_id = public.current_organization_id()
+    )
+  )
+  with check (
+    bucket_id = 'order-assistance-photos'
+    and public.is_staff_or_admin()
+    and exists (
+      select 1
+      from public.service_orders s
+      where s.id::text = split_part(name, '/', 1)
+        and s.organization_id = public.current_organization_id()
+    )
+  );
+
+-- Atualiza resumo de storage do admin para incluir fotos da assistência
+create or replace function public.admin_storage_usage_summary(p_organization_id uuid)
+returns jsonb
+language sql
+security definer
+set search_path = public, storage
+as $$
+  with storage_sizes as (
+    select
+      o.bucket_id,
+      o.name,
+      case
+        when (o.metadata->>'size') ~ '^[0-9]+$' then (o.metadata->>'size')::bigint
+        else 0
+      end as size_bytes
+    from storage.objects o
+  ),
+  project_buckets as (
+    select
+      s.bucket_id,
+      count(*)::integer as file_count,
+      coalesce(sum(s.size_bytes), 0)::bigint as bytes
+    from storage_sizes s
+    group by s.bucket_id
+  ),
+  category_paths as (
+    select
+      'os_entry'::text as category,
+      'order-entry-photos'::text as bucket_id,
+      p.storage_path as name
+    from public.service_order_entry_photos p
+    where p.organization_id = p_organization_id
+      and nullif(trim(p.storage_path), '') is not null
+
+    union all
+
+    select
+      'os_exit'::text as category,
+      'order-exit-photos'::text as bucket_id,
+      p.storage_path as name
+    from public.service_order_exit_photos p
+    where p.organization_id = p_organization_id
+      and nullif(trim(p.storage_path), '') is not null
+
+    union all
+
+    select
+      'os_assistance'::text as category,
+      'order-assistance-photos'::text as bucket_id,
+      p.storage_path as name
+    from public.service_order_assistance_photos p
+    where p.organization_id = p_organization_id
+      and nullif(trim(p.storage_path), '') is not null
+
+    union all
+
+    select
+      'whatsapp'::text as category,
+      'whatsapp-media'::text as bucket_id,
+      s.name
+    from storage_sizes s
+    where s.bucket_id = 'whatsapp-media'
+      and s.name like (p_organization_id::text || '/%')
+
+    union all
+
+    select
+      'resale'::text as category,
+      'resale-device-photos'::text as bucket_id,
+      d.image_storage_path as name
+    from public.resale_devices d
+    where d.organization_id = p_organization_id
+      and nullif(trim(coalesce(d.image_storage_path, '')), '') is not null
+
+    union all
+
+    select
+      'resale'::text as category,
+      'resale-device-photos'::text as bucket_id,
+      gallery_path as name
+    from public.resale_devices d
+    cross join lateral unnest(coalesce(d.image_gallery_paths, '{}'::text[])) as gallery_path
+    where d.organization_id = p_organization_id
+      and nullif(trim(gallery_path), '') is not null
+  ),
+  category_totals as (
+    select
+      p.category,
+      count(distinct (p.bucket_id || '/' || p.name))::integer as file_count,
+      coalesce(sum(s.size_bytes), 0)::bigint as bytes
+    from category_paths p
+    left join storage_sizes s
+      on s.bucket_id = p.bucket_id
+     and s.name = p.name
+    group by p.category
+  ),
+  categories as (
+    select *
+    from (
+      values
+        ('os_entry'::text, 'Fotos de entrada de OS'::text),
+        ('os_exit'::text, 'Fotos de saída de OS'::text),
+        ('os_assistance'::text, 'Fotos da assistência de OS'::text),
+        ('whatsapp'::text, 'Imagens do WhatsApp'::text),
+        ('resale'::text, 'Fotos de seminovos'::text)
+    ) as c(category, label)
+  )
+  select jsonb_build_object(
+    'project_total_bytes',
+    coalesce((select sum(bytes) from project_buckets), 0),
+    'project_buckets',
+    coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'bucketId', bucket_id,
+          'fileCount', file_count,
+          'bytes', bytes
+        )
+        order by bytes desc, bucket_id asc
+      )
+      from project_buckets
+    ), '[]'::jsonb),
+    'org_total_bytes',
+    coalesce((select sum(bytes) from category_totals), 0),
+    'org_categories',
+    coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'key', c.category,
+          'label', c.label,
+          'fileCount', coalesce(t.file_count, 0),
+          'bytes', coalesce(t.bytes, 0)
+        )
+        order by
+          case c.category
+            when 'os_entry' then 1
+            when 'os_exit' then 2
+            when 'os_assistance' then 3
+            when 'whatsapp' then 4
+            when 'resale' then 5
+            else 99
+          end
+      )
+      from categories c
+      left join category_totals t on t.category = c.category
+    ), '[]'::jsonb)
+  );
+$$;

--- a/supabase/migrations/20260814130000_device_catalog_shared_host_read.sql
+++ b/supabase/migrations/20260814130000_device_catalog_shared_host_read.sql
@@ -1,0 +1,113 @@
+-- Catálogo de aparelhos: leitura do host (Conectize) para todas as orgs;
+-- escrita continua apenas na organização atual.
+
+create or replace function public.host_organization_id ()
+returns uuid
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select o.id
+  from public.organizations o
+  where o.is_host = true
+  order by o.created_at asc
+  limit 1;
+$$;
+
+revoke all on function public.host_organization_id () from public;
+grant execute on function public.host_organization_id () to authenticated;
+grant execute on function public.host_organization_id () to service_role;
+
+-- device_brands
+drop policy if exists device_brands_staff_select_org on public.device_brands;
+create policy device_brands_staff_select_org
+  on public.device_brands for select
+  to authenticated
+  using (
+    public.is_staff_or_admin()
+    and (
+      device_brands.organization_id = public.current_organization_id()
+      or device_brands.organization_id = public.host_organization_id()
+    )
+  );
+
+drop policy if exists device_brands_retailer_select_org on public.device_brands;
+create policy device_brands_retailer_select_org
+  on public.device_brands for select
+  to authenticated
+  using (
+    public.is_retailer()
+    and (
+      device_brands.organization_id = public.host_organization_id()
+      or exists (
+        select 1
+        from public.customer_portal_members m
+        join public.customers c on c.id = m.customer_id
+        where m.user_id = auth.uid()
+          and c.organization_id = device_brands.organization_id
+      )
+    )
+  );
+
+-- device_types
+drop policy if exists device_types_staff_select_org on public.device_types;
+create policy device_types_staff_select_org
+  on public.device_types for select
+  to authenticated
+  using (
+    public.is_staff_or_admin()
+    and (
+      device_types.organization_id = public.current_organization_id()
+      or device_types.organization_id = public.host_organization_id()
+    )
+  );
+
+drop policy if exists device_types_retailer_select_org on public.device_types;
+create policy device_types_retailer_select_org
+  on public.device_types for select
+  to authenticated
+  using (
+    public.is_retailer()
+    and (
+      device_types.organization_id = public.host_organization_id()
+      or exists (
+        select 1
+        from public.customer_portal_members m
+        join public.customers c on c.id = m.customer_id
+        where m.user_id = auth.uid()
+          and c.organization_id = device_types.organization_id
+      )
+    )
+  );
+
+-- device_models
+drop policy if exists device_models_staff_select_org on public.device_models;
+create policy device_models_staff_select_org
+  on public.device_models for select
+  to authenticated
+  using (
+    public.is_staff_or_admin()
+    and (
+      device_models.organization_id = public.current_organization_id()
+      or device_models.organization_id = public.host_organization_id()
+    )
+  );
+
+drop policy if exists device_models_retailer_select_org on public.device_models;
+create policy device_models_retailer_select_org
+  on public.device_models for select
+  to authenticated
+  using (
+    public.is_retailer()
+    and (
+      device_models.organization_id = public.host_organization_id()
+      or exists (
+        select 1
+        from public.customer_portal_members m
+        join public.customers c on c.id = m.customer_id
+        where m.user_id = auth.uid()
+          and c.organization_id = device_models.organization_id
+      )
+    )
+  );

--- a/supabase/migrations/20260814140000_commission_paid_at.sql
+++ b/supabase/migrations/20260814140000_commission_paid_at.sql
@@ -1,0 +1,15 @@
+-- Controle de pagamento de comissões (OS finalizada e aparelho vendido)
+
+alter table public.service_orders
+  add column if not exists commission_paid_at timestamptz;
+
+alter table public.resale_devices
+  add column if not exists commission_paid_at timestamptz;
+
+create index if not exists service_orders_commission_pending_idx
+  on public.service_orders (organization_id, closed_at desc)
+  where commission_user_id is not null and commission_paid_at is null;
+
+create index if not exists resale_devices_commission_pending_idx
+  on public.resale_devices (organization_id, sale_date desc)
+  where sold = true and commission_paid_at is null;


### PR DESCRIPTION
- Updated `OrderPhotosStage` to include "assistance" for better categorization of photos.
- Modified `OrderEntryPhotos` component to handle assistance photos, including new API paths and toast messages for user feedback.
- Adjusted `OrdemDetalhePageContent` to integrate assistance photo count and display.
- Enhanced public order page to show assistance photos alongside entry and exit photos.
- Updated related services and cleanup functions to manage assistance photos effectively.
- Ensured strict TypeScript compliance and optimized for performance, adhering to Lighthouse standards throughout the changes.